### PR TITLE
ci: add GitHub Actions workflows for backend tests and JavaDoc genera…

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -1,0 +1,41 @@
+name: Backend Tests
+
+on:
+  push:
+    branches:
+      - master
+      - dev
+      - features/workflows
+  pull_request:
+    branches:
+      - master
+      - dev
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    - name: Set up JDK 17
+      uses: actions/setup-java@v3
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+        server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
+        settings-path: ${{ github.workspace }} # location for the settings.xml file
+
+    - name: Cache Maven packages
+      uses: actions/cache@v2
+      with:
+        path: ~/.m2/repository
+        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: ${{ runner.os }}-maven
+
+    - name: Install dependencies
+      run: mvn install -DskipTests
+
+    - name: Run tests
+      run: mvn test

--- a/.github/workflows/generate-javadoc.yml
+++ b/.github/workflows/generate-javadoc.yml
@@ -1,0 +1,44 @@
+name: Generate JavaDoc
+
+on:
+  push:
+    branches:
+      - master
+      - dev
+      - features/workflows
+  pull_request:
+    branches:
+      - master
+      - dev
+
+jobs:
+  javadoc:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
+          settings-path: ${{ github.workspace }} # location for the settings.xml file
+
+      - name: Cache Maven packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-maven
+
+      - name: Generate JavaDoc
+        run: mvn javadoc:javadoc
+
+      - name: Upload JavaDoc
+        uses: actions/upload-artifact@v4
+        with:
+          name: javadoc
+          path: target/site/apidocs


### PR DESCRIPTION
This pull request adds two new GitHub Actions workflows to automate backend tests and JavaDoc generation. These workflows are designed to run on specific branches and include steps for setting up the environment, caching dependencies, and performing the necessary tasks.

### New GitHub Actions Workflows:

* [`.github/workflows/backend-tests.yml`](diffhunk://#diff-9c6cf26586ede5c13edc79888921fe097b68599bd9ec24ef2d4500bc8ba346cdR1-R41): Adds a workflow to run backend tests on `master`, `dev`, and `features/workflows` branches, including steps for checking out the repository, setting up JDK 17, caching Maven packages, installing dependencies, and running tests.
* [`.github/workflows/generate-javadoc.yml`](diffhunk://#diff-e7a5fd25db29480582cec7468dc966fb23ffeedc17219f6be73fa4f54d4c5b80R1-R44): Adds a workflow to generate JavaDoc on `master`, `dev`, and `features/workflows` branches, including steps for checking out the repository, setting up JDK 17, caching Maven packages, generating JavaDoc, and uploading the JavaDoc artifact.…tion