### PR TITLE
Features/workflow

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - master
       - dev
-      - features/workflows
+      - features/workflow
   pull_request:
     branches:
       - master
@@ -17,10 +17,10 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4.2.2
 
     - name: Set up JDK 17
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4.7.0
       with:
         java-version: '17'
         distribution: 'temurin'
@@ -28,7 +28,7 @@ jobs:
         settings-path: ${{ github.workspace }} # location for the settings.xml file
 
     - name: Cache Maven packages
-      uses: actions/cache@v2
+      uses: actions/cache@v3.4.3
       with:
         path: ~/.m2/repository
         key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -1,0 +1,41 @@
+name: Backend Tests
+
+on:
+  push:
+    branches:
+      - master
+      - dev
+      - features/workflows
+  pull_request:
+    branches:
+      - master
+      - dev
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    - name: Set up JDK 17
+      uses: actions/setup-java@v3
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+        server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
+        settings-path: ${{ github.workspace }} # location for the settings.xml file
+
+    - name: Cache Maven packages
+      uses: actions/cache@v2
+      with:
+        path: ~/.m2/repository
+        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: ${{ runner.os }}-maven
+
+    - name: Install dependencies
+      run: mvn install -DskipTests
+
+    - name: Run tests
+      run: mvn test

--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -16,26 +16,28 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4.2.2
+      - name: Checkout repository
+        uses: actions/checkout@v4.2.2
 
-    - name: Set up JDK 17
-      uses: actions/setup-java@v4.7.0
-      with:
-        java-version: '17'
-        distribution: 'temurin'
-        server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
-        settings-path: ${{ github.workspace }} # location for the settings.xml file
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4.7.0
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          server-id: github
+          settings-path: ${{ github.workspace }}
 
-    - name: Cache Maven packages
-      uses: actions/cache@v3.4.3
-      with:
-        path: ~/.m2/repository
-        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-        restore-keys: ${{ runner.os }}-maven
+      - name: Cache Maven packages
+        uses: actions/cache@v3.4.3
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-maven
 
-    - name: Install dependencies
-      run: mvn install -DskipTests
+      - name: Install dependencies
+        run: mvn install -DskipTests
+        working-directory: ./Backend
 
-    - name: Run tests
-      run: mvn test
+      - name: Run tests
+        run: mvn test
+        working-directory: ./Backend

--- a/.github/workflows/generate-javadoc.yml
+++ b/.github/workflows/generate-javadoc.yml
@@ -1,0 +1,44 @@
+name: Generate JavaDoc
+
+on:
+  push:
+    branches:
+      - master
+      - dev
+      - features/workflows
+  pull_request:
+    branches:
+      - master
+      - dev
+
+jobs:
+  javadoc:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
+          settings-path: ${{ github.workspace }} # location for the settings.xml file
+
+      - name: Cache Maven packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-maven
+
+      - name: Generate JavaDoc
+        run: mvn javadoc:javadoc
+
+      - name: Upload JavaDoc
+        uses: actions/upload-artifact@v4
+        with:
+          name: javadoc
+          path: target/site/apidocs

--- a/.github/workflows/generate-javadoc.yml
+++ b/.github/workflows/generate-javadoc.yml
@@ -24,8 +24,8 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
-          server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
-          settings-path: ${{ github.workspace }} # location for the settings.xml file
+          server-id: github
+          settings-path: ${{ github.workspace }}
 
       - name: Cache Maven packages
         uses: actions/cache@v3.4.3
@@ -36,9 +36,10 @@ jobs:
 
       - name: Generate JavaDoc
         run: mvn javadoc:javadoc
+        working-directory: ./Backend
 
       - name: Upload JavaDoc
         uses: actions/upload-artifact@v4
         with:
           name: javadoc
-          path: target/site/apidocs
+          path: Backend/target/site/apidocs

--- a/.github/workflows/generate-javadoc.yml
+++ b/.github/workflows/generate-javadoc.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - master
       - dev
-      - features/workflows
+      - features/workflow
   pull_request:
     branches:
       - master
@@ -17,10 +17,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.2.2
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4.7.0
         with:
           java-version: '17'
           distribution: 'temurin'
@@ -28,7 +28,7 @@ jobs:
           settings-path: ${{ github.workspace }} # location for the settings.xml file
 
       - name: Cache Maven packages
-        uses: actions/cache@v2
+        uses: actions/cache@v3.4.3
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}


### PR DESCRIPTION
This pull request introduces two new GitHub Actions workflows to automate backend testing and JavaDoc generation. These workflows ensure that tests are run and documentation is generated on specific branches and pull requests.

New GitHub Actions workflows:

* [`.github/workflows/backend-tests.yml`](diffhunk://#diff-9c6cf26586ede5c13edc79888921fe097b68599bd9ec24ef2d4500bc8ba346cdR1-R43): Adds a workflow to run backend tests on pushes and pull requests to the `master`, `dev`, and `features/workflow` branches. The workflow sets up JDK 17, caches Maven packages, installs dependencies, and runs tests.

* [`.github/workflows/generate-javadoc.yml`](diffhunk://#diff-e7a5fd25db29480582cec7468dc966fb23ffeedc17219f6be73fa4f54d4c5b80R1-R45): Adds a workflow to generate JavaDoc on pushes and pull requests to the `master`, `dev`, and `features/workflow` branches. The workflow sets up JDK 17, caches Maven packages, generates JavaDoc, and uploads the generated documentation as an artifact.