### PR TITLE
Features/testunit

### DIFF
--- a/Backend/src/main/java/fr/knap/testunitaire_esiee/config/Config.java
+++ b/Backend/src/main/java/fr/knap/testunitaire_esiee/config/Config.java
@@ -11,6 +11,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Configuration class for setting up initial data.
@@ -33,242 +35,243 @@ public class Config {
             ObjetService objetService) {
 
         return args -> {
-            Utilisateur user1 = new Utilisateur(
+            List<Utilisateur> utilisateurs = new ArrayList<>();
+
+            utilisateurs.add(new Utilisateur(
                     "Nicolas",
                     "testnicolas", "nicolas@test.testa",
                     "Test",
                     "Nicolas"
-            );
+            ));
 
-            Utilisateur user2 = new Utilisateur(
+            utilisateurs.add(new Utilisateur(
                     "Sophie",
                     "sophietest", "sophie@test.com",
                     "Test",
                     "Sophie"
-            );
+            ));
 
-            Utilisateur user3 = new Utilisateur(
+            utilisateurs.add(new Utilisateur(
                     "Jean",
                     "jeanpierre", "jean.pierre@test.net",
                     "Pierre",
                     "Jean"
-            );
+            ));
 
-            Utilisateur user4 = new Utilisateur(
+            utilisateurs.add(new Utilisateur(
                     "Laura",
                     "lauratest", "laura@test.org",
                     "Test",
                     "Laura"
-            );
+            ));
 
-            Utilisateur user5 = new Utilisateur(
+            utilisateurs.add(new Utilisateur(
                     "David",
                     "david123", "david@test.fr",
                     "Test",
                     "David"
-            );
-            utilisateurRepository.save(user1);
-            utilisateurRepository.save(user2);
-            utilisateurRepository.save(user3);
-            utilisateurRepository.save(user4);
-            utilisateurRepository.save(user5);
+            ));
+
+            utilisateurs.forEach(utilisateurRepository::save);
+
+            int numberOfUsers = utilisateurs.size();
 
             Objet objet = new Objet(
-                    utilisateurService.obtenirUtilisateurParId((long) ((Math.random() * 5) + 1)), "NVIDIA RTX 4070SUPER",
+                    utilisateurService.obtenirUtilisateurParId((long) ((Math.random() * numberOfUsers) + 1)), "NVIDIA RTX 4070SUPER",
                     "Carte graphique Nvidia RTX 4070SUPER",
                     CategorieObjet.GAMING, LocalDateTime.now());
             objetRepository.save(objet);
 
             Objet objet1 = new Objet(
-                    utilisateurService.obtenirUtilisateurParId((long) ((Math.random() * 5) + 1)), "Fauteuil IKEA Markus",
+                    utilisateurService.obtenirUtilisateurParId((long) ((Math.random() * numberOfUsers) + 1)), "Fauteuil IKEA Markus",
                     "Fauteuil de bureau ergonomique avec support lombaire.",
                     CategorieObjet.MOBILIER, LocalDateTime.now());
             objetRepository.save(objet1);
 
             Objet objet2 = new Objet(
-                    utilisateurService.obtenirUtilisateurParId((long) ((Math.random() * 5) + 1)), "Table basse Maison du Monde",
+                    utilisateurService.obtenirUtilisateurParId((long) ((Math.random() * numberOfUsers) + 1)), "Table basse Maison du Monde",
                     "Table basse en bois massif avec rangement intégré.",
                     CategorieObjet.MOBILIER, LocalDateTime.now());
             objetRepository.save(objet2);
 
             Objet objet3 = new Objet(
-                    utilisateurService.obtenirUtilisateurParId((long) ((Math.random() * 5) + 1)), "Tondeuse Bosch Rotak 43",
+                    utilisateurService.obtenirUtilisateurParId((long) ((Math.random() * numberOfUsers) + 1)), "Tondeuse Bosch Rotak 43",
                     "Tondeuse à gazon électrique avec bac de ramassage.",
                     CategorieObjet.JARDINAGE, LocalDateTime.now());
             objetRepository.save(objet3);
 
             Objet objet4 = new Objet(
-                    utilisateurService.obtenirUtilisateurParId((long) ((Math.random() * 5) + 1)), "Arrosoir Gardena 10L",
+                    utilisateurService.obtenirUtilisateurParId((long) ((Math.random() * numberOfUsers) + 1)), "Arrosoir Gardena 10L",
                     "Arrosoir robuste en métal avec bec verseur précis.",
                     CategorieObjet.JARDINAGE, LocalDateTime.now());
             objetRepository.save(objet4);
 
             Objet objet5 = new Objet(
-                    utilisateurService.obtenirUtilisateurParId((long) ((Math.random() * 5) + 1)), "Clavier mécanique Logitech G915",
+                    utilisateurService.obtenirUtilisateurParId((long) ((Math.random() * numberOfUsers) + 1)), "Clavier mécanique Logitech G915",
                     "Clavier mécanique sans fil avec switchs tactiles.",
                     CategorieObjet.INFORMATIQUE, LocalDateTime.now());
             objetRepository.save(objet5);
 
             Objet objet6 = new Objet(
-                    utilisateurService.obtenirUtilisateurParId((long) ((Math.random() * 5) + 1)), "Écran Dell UltraSharp 27\"",
+                    utilisateurService.obtenirUtilisateurParId((long) ((Math.random() * numberOfUsers) + 1)), "Écran Dell UltraSharp 27\"",
                     "Écran 4K UHD avec technologie IPS.",
                     CategorieObjet.INFORMATIQUE, LocalDateTime.now());
             objetRepository.save(objet6);
 
             Objet objet7 = new Objet(
-                    utilisateurService.obtenirUtilisateurParId((long) ((Math.random() * 5) + 1)), "Manette Xbox Elite Series 2",
+                    utilisateurService.obtenirUtilisateurParId((long) ((Math.random() * numberOfUsers) + 1)), "Manette Xbox Elite Series 2",
                     "Manette pro personnalisable avec paddles.",
                     CategorieObjet.GAMING, LocalDateTime.now());
             objetRepository.save(objet7);
 
             Objet objet8 = new Objet(
-                    utilisateurService.obtenirUtilisateurParId((long) ((Math.random() * 5) + 1)), "Casque SteelSeries Arctis Pro",
+                    utilisateurService.obtenirUtilisateurParId((long) ((Math.random() * numberOfUsers) + 1)), "Casque SteelSeries Arctis Pro",
                     "Casque gaming haute fidélité avec son surround.",
                     CategorieObjet.GAMING, LocalDateTime.now());
             objetRepository.save(objet8);
 
             Objet objet9 = new Objet(
-                    utilisateurService.obtenirUtilisateurParId((long) ((Math.random() * 5) + 1)), "Perceuse Bosch GSR 12V",
+                    utilisateurService.obtenirUtilisateurParId((long) ((Math.random() * numberOfUsers) + 1)), "Perceuse Bosch GSR 12V",
                     "Perceuse-visseuse sans fil avec batterie lithium-ion.",
                     CategorieObjet.OUTILS, LocalDateTime.now());
             objetRepository.save(objet9);
 
             Objet objet10 = new Objet(
-                    utilisateurService.obtenirUtilisateurParId((long) ((Math.random() * 5) + 1)), "Timbre Napoléon III 1863",
+                    utilisateurService.obtenirUtilisateurParId((long) ((Math.random() * numberOfUsers) + 1)), "Timbre Napoléon III 1863",
                     "Timbre rare en bon état, valeur collection.",
                     CategorieObjet.COLLECTION, LocalDateTime.now());
             objetRepository.save(objet10);
 
             Objet objet11 = new Objet(
-                    utilisateurService.obtenirUtilisateurParId((long) ((Math.random() * 5) + 1)), "Roman 'Dune' de Frank Herbert",
+                    utilisateurService.obtenirUtilisateurParId((long) ((Math.random() * numberOfUsers) + 1)), "Roman 'Dune' de Frank Herbert",
                     "Édition collector avec couverture rigide.",
                     CategorieObjet.LITTERATURE, LocalDateTime.now());
             objetRepository.save(objet11);
 
             Objet objet12 = new Objet(
-                    utilisateurService.obtenirUtilisateurParId((long) ((Math.random() * 5) + 1)), "Sweat Nike Tech Fleece",
+                    utilisateurService.obtenirUtilisateurParId((long) ((Math.random() * numberOfUsers) + 1)), "Sweat Nike Tech Fleece",
                     "Sweat à capuche gris, taille L.",
                     CategorieObjet.VETEMENTS, LocalDateTime.now());
             objetRepository.save(objet12);
 
             Objet objet13 = new Objet(
-                    utilisateurService.obtenirUtilisateurParId((long) ((Math.random() * 5) + 1)), "Aspirateur Dyson V11",
+                    utilisateurService.obtenirUtilisateurParId((long) ((Math.random() * numberOfUsers) + 1)), "Aspirateur Dyson V11",
                     "Aspirateur sans fil puissant avec station d'accueil.",
                     CategorieObjet.ELECTROMENAGER, LocalDateTime.now());
             objetRepository.save(objet13);
 
             Objet objet14 = new Objet(
-                    utilisateurService.obtenirUtilisateurParId((long) ((Math.random() * 5) + 1)), "Porte-clés Marvel",
+                    utilisateurService.obtenirUtilisateurParId((long) ((Math.random() * numberOfUsers) + 1)), "Porte-clés Marvel",
                     "Porte-clés en métal avec logo Avengers.",
                     CategorieObjet.AUTRE, LocalDateTime.now());
             objetRepository.save(objet14);
 
             Objet objet15 = new Objet(
-                    utilisateurService.obtenirUtilisateurParId((long) ((Math.random() * 5) + 1)), "Tournevis multifonction Bosch",
+                    utilisateurService.obtenirUtilisateurParId((long) ((Math.random() * numberOfUsers) + 1)), "Tournevis multifonction Bosch",
                     "Tournevis avec embouts interchangeables.",
                     CategorieObjet.OUTILS, LocalDateTime.now());
             objetRepository.save(objet15);
 
             Objet objet16 = new Objet(
-                    utilisateurService.obtenirUtilisateurParId((long) ((Math.random() * 5) + 1)), "Console PS5",
+                    utilisateurService.obtenirUtilisateurParId((long) ((Math.random() * numberOfUsers) + 1)), "Console PS5",
                     "Console Sony PlayStation 5 en excellent état.",
                     CategorieObjet.GAMING, LocalDateTime.now());
             objetRepository.save(objet16);
 
             Objet objet17 = new Objet(
-                    utilisateurService.obtenirUtilisateurParId((long) ((Math.random() * 5) + 1)), "MacBook Pro M2",
+                    utilisateurService.obtenirUtilisateurParId((long) ((Math.random() * numberOfUsers) + 1)), "MacBook Pro M2",
                     "Ordinateur portable Apple, 16 Go RAM, 512 Go SSD.",
                     CategorieObjet.INFORMATIQUE, LocalDateTime.now());
             objetRepository.save(objet17);
 
             Objet objet18 = new Objet(
-                    utilisateurService.obtenirUtilisateurParId((long) ((Math.random() * 5) + 1)), "Veste The North Face",
+                    utilisateurService.obtenirUtilisateurParId((long) ((Math.random() * numberOfUsers) + 1)), "Veste The North Face",
                     "Veste imperméable, idéale pour l'hiver.",
                     CategorieObjet.VETEMENTS, LocalDateTime.now());
             objetRepository.save(objet18);
 
             Objet objet19 = new Objet(
-                    utilisateurService.obtenirUtilisateurParId((long) ((Math.random() * 5) + 1)), "Machine à café Nespresso Vertuo",
+                    utilisateurService.obtenirUtilisateurParId((long) ((Math.random() * numberOfUsers) + 1)), "Machine à café Nespresso Vertuo",
                     "Machine avec capsules compatibles Vertuo.",
                     CategorieObjet.ELECTROMENAGER, LocalDateTime.now());
             objetRepository.save(objet19);
 
             Objet objet20 = new Objet(
-                    utilisateurService.obtenirUtilisateurParId((long) ((Math.random() * 5) + 1)), "Lampe Philips Hue",
+                    utilisateurService.obtenirUtilisateurParId((long) ((Math.random() * numberOfUsers) + 1)), "Lampe Philips Hue",
                     "Lampe connectée avec variation de couleurs.",
                     CategorieObjet.MOBILIER, LocalDateTime.now());
             objetRepository.save(objet20);
 
             Objet objet21 = new Objet(
-                    utilisateurService.obtenirUtilisateurParId((long) ((Math.random() * 5) + 1)), "Grille-pain SMEG",
+                    utilisateurService.obtenirUtilisateurParId((long) ((Math.random() * numberOfUsers) + 1)), "Grille-pain SMEG",
                     "Grille-pain rétro avec thermostat réglable.",
                     CategorieObjet.ELECTROMENAGER, LocalDateTime.now());
             objetRepository.save(objet21);
 
             Objet objet22 = new Objet(
-                    utilisateurService.obtenirUtilisateurParId((long) ((Math.random() * 5) + 1)), "Tondeuse Husqvarna Automower",
+                    utilisateurService.obtenirUtilisateurParId((long) ((Math.random() * numberOfUsers) + 1)), "Tondeuse Husqvarna Automower",
                     "Robot tondeuse autonome.",
                     CategorieObjet.JARDINAGE, LocalDateTime.now());
             objetRepository.save(objet22);
 
             Objet objet23 = new Objet(
-                    utilisateurService.obtenirUtilisateurParId((long) ((Math.random() * 5) + 1)), "Préférence d'échange : Roomba",
+                    utilisateurService.obtenirUtilisateurParId((long) ((Math.random() * numberOfUsers) + 1)), "Préférence d'échange : Roomba",
                     "Aspirateur intelligent recherché en échange.",
                     CategorieObjet.AUTRE, LocalDateTime.now());
             objetRepository.save(objet23);
 
             Objet objet24 = new Objet(
-                    utilisateurService.obtenirUtilisateurParId((long) ((Math.random() * 5) + 1)), "Sac à dos Eastpak",
+                    utilisateurService.obtenirUtilisateurParId((long) ((Math.random() * numberOfUsers) + 1)), "Sac à dos Eastpak",
                     "Sac à dos noir, capacité 24L.",
                     CategorieObjet.AUTRE, LocalDateTime.now());
             objetRepository.save(objet24);
 
             Objet objet25 = new Objet(
-                    utilisateurService.obtenirUtilisateurParId((long) ((Math.random() * 5) + 1)), "Jeu Zelda: Tears of the Kingdom",
+                    utilisateurService.obtenirUtilisateurParId((long) ((Math.random() * numberOfUsers) + 1)), "Jeu Zelda: Tears of the Kingdom",
                     "Jeu Nintendo Switch, édition standard.",
                     CategorieObjet.GAMING, LocalDateTime.now());
             objetRepository.save(objet25);
 
             Objet objet26 = new Objet(
-                    utilisateurService.obtenirUtilisateurParId((long) ((Math.random() * 5) + 1)), "Bureau en bois massif",
+                    utilisateurService.obtenirUtilisateurParId((long) ((Math.random() * numberOfUsers) + 1)), "Bureau en bois massif",
                     "Bureau spacieux avec tiroirs intégrés.",
                     CategorieObjet.MOBILIER, LocalDateTime.now());
             objetRepository.save(objet26);
 
             Objet objet27 = new Objet(
-                    utilisateurService.obtenirUtilisateurParId((long) ((Math.random() * 5) + 1)), "Souris Logitech MX Master 3",
+                    utilisateurService.obtenirUtilisateurParId((long) ((Math.random() * numberOfUsers) + 1)), "Souris Logitech MX Master 3",
                     "Souris sans fil ergonomique pour travail intensif.",
                     CategorieObjet.INFORMATIQUE, LocalDateTime.now());
             objetRepository.save(objet27);
 
             Objet objet28 = new Objet(
-                    utilisateurService.obtenirUtilisateurParId((long) ((Math.random() * 5) + 1)), "Livres Harry Potter édition Gallimard",
+                    utilisateurService.obtenirUtilisateurParId((long) ((Math.random() * numberOfUsers) + 1)), "Livres Harry Potter édition Gallimard",
                     "Collection complète, bon état.",
                     CategorieObjet.LITTERATURE, LocalDateTime.now());
             objetRepository.save(objet28);
 
             Objet objet29 = new Objet(
-                    utilisateurService.obtenirUtilisateurParId((long) ((Math.random() * 5) + 1)), "Lunettes de soleil Ray-Ban Aviator",
+                    utilisateurService.obtenirUtilisateurParId((long) ((Math.random() * numberOfUsers) + 1)), "Lunettes de soleil Ray-Ban Aviator",
                     "Verres polarisés, monture dorée.",
                     CategorieObjet.AUTRE, LocalDateTime.now());
             objetRepository.save(objet29);
 
             Objet objet30 = new Objet(
-                    utilisateurService.obtenirUtilisateurParId((long) ((Math.random() * 5) + 1)), "Gants de jardinage Wolf-Garten",
+                    utilisateurService.obtenirUtilisateurParId((long) ((Math.random() * numberOfUsers) + 1)), "Gants de jardinage Wolf-Garten",
                     "Gants résistants pour la taille et plantation.",
                     CategorieObjet.JARDINAGE, LocalDateTime.now());
             objetRepository.save(objet30);
 
             Echange echange = new Echange(
-                    objetService.obtenirObjetParId(9L), objetService.obtenirObjetParId((long) ((Math.random() * 5) + 1)),
+                    objetService.obtenirObjetParId(9L), objetService.obtenirObjetParId((long) ((Math.random() * numberOfUsers) + 1)),
                     LocalDateTime.now(), Etat.ATTENTE, null);
             echangeRepository.save(echange);
             Echange echange2 = new Echange(
-                    objetService.obtenirObjetParId(8L), objetService.obtenirObjetParId((long) ((Math.random() * 5) + 1)),
+                    objetService.obtenirObjetParId(8L), objetService.obtenirObjetParId((long) ((Math.random() * numberOfUsers) + 1)),
                     LocalDateTime.now(), Etat.ACCEPTE, LocalDateTime.now().plusDays(2));
             echangeRepository.save(echange2);
             Echange echange3 = new Echange(
-                    objetService.obtenirObjetParId(10L), objetService.obtenirObjetParId((long) ((Math.random() * 5) + 1)),
+                    objetService.obtenirObjetParId(10L), objetService.obtenirObjetParId((long) ((Math.random() * numberOfUsers) + 1)),
                     LocalDateTime.now().minusDays(1), Etat.REFUSE, LocalDateTime.now().plusDays(3));
             echangeRepository.save(echange3);
         };

--- a/Backend/src/main/java/fr/knap/testunitaire_esiee/config/Config.java
+++ b/Backend/src/main/java/fr/knap/testunitaire_esiee/config/Config.java
@@ -73,174 +73,206 @@ public class Config {
             utilisateurRepository.save(user4);
             utilisateurRepository.save(user5);
 
-            for (int i = 0; i < 5; i++) {
-                Objet objet = new Objet(
-                        utilisateurService.obtenirUtilisateurParId(1L), "NVIDIA RTX 4070SUPER", "Carte graphique Nvidia RTX 4070SUPER",
-                        CategorieObjet.GAMING, LocalDateTime.now());
-                objetRepository.save(objet);
-            }
+            Objet objet = new Objet(
+                    utilisateurService.obtenirUtilisateurParId((long) ((Math.random() * 5) + 1)), "NVIDIA RTX 4070SUPER",
+                    "Carte graphique Nvidia RTX 4070SUPER",
+                    CategorieObjet.GAMING, LocalDateTime.now());
+            objetRepository.save(objet);
+
             Objet objet1 = new Objet(
-                    utilisateurService.obtenirUtilisateurParId(1L), "Fauteuil IKEA Markus", "Fauteuil de bureau ergonomique avec support lombaire.",
+                    utilisateurService.obtenirUtilisateurParId((long) ((Math.random() * 5) + 1)), "Fauteuil IKEA Markus",
+                    "Fauteuil de bureau ergonomique avec support lombaire.",
                     CategorieObjet.MOBILIER, LocalDateTime.now());
             objetRepository.save(objet1);
 
             Objet objet2 = new Objet(
-                    utilisateurService.obtenirUtilisateurParId(2L), "Table basse Maison du Monde", "Table basse en bois massif avec rangement intégré.",
+                    utilisateurService.obtenirUtilisateurParId((long) ((Math.random() * 5) + 1)), "Table basse Maison du Monde",
+                    "Table basse en bois massif avec rangement intégré.",
                     CategorieObjet.MOBILIER, LocalDateTime.now());
             objetRepository.save(objet2);
 
             Objet objet3 = new Objet(
-                    utilisateurService.obtenirUtilisateurParId(3L), "Tondeuse Bosch Rotak 43", "Tondeuse à gazon électrique avec bac de ramassage.",
+                    utilisateurService.obtenirUtilisateurParId((long) ((Math.random() * 5) + 1)), "Tondeuse Bosch Rotak 43",
+                    "Tondeuse à gazon électrique avec bac de ramassage.",
                     CategorieObjet.JARDINAGE, LocalDateTime.now());
             objetRepository.save(objet3);
 
             Objet objet4 = new Objet(
-                    utilisateurService.obtenirUtilisateurParId(4L), "Arrosoir Gardena 10L", "Arrosoir robuste en métal avec bec verseur précis.",
+                    utilisateurService.obtenirUtilisateurParId((long) ((Math.random() * 5) + 1)), "Arrosoir Gardena 10L",
+                    "Arrosoir robuste en métal avec bec verseur précis.",
                     CategorieObjet.JARDINAGE, LocalDateTime.now());
             objetRepository.save(objet4);
 
             Objet objet5 = new Objet(
-                    utilisateurService.obtenirUtilisateurParId(5L), "Clavier mécanique Logitech G915", "Clavier mécanique sans fil avec switchs tactiles.",
+                    utilisateurService.obtenirUtilisateurParId((long) ((Math.random() * 5) + 1)), "Clavier mécanique Logitech G915",
+                    "Clavier mécanique sans fil avec switchs tactiles.",
                     CategorieObjet.INFORMATIQUE, LocalDateTime.now());
             objetRepository.save(objet5);
 
             Objet objet6 = new Objet(
-                    utilisateurService.obtenirUtilisateurParId(6L), "Écran Dell UltraSharp 27\"", "Écran 4K UHD avec technologie IPS.",
+                    utilisateurService.obtenirUtilisateurParId((long) ((Math.random() * 5) + 1)), "Écran Dell UltraSharp 27\"",
+                    "Écran 4K UHD avec technologie IPS.",
                     CategorieObjet.INFORMATIQUE, LocalDateTime.now());
             objetRepository.save(objet6);
 
             Objet objet7 = new Objet(
-                    utilisateurService.obtenirUtilisateurParId(7L), "Manette Xbox Elite Series 2", "Manette pro personnalisable avec paddles.",
+                    utilisateurService.obtenirUtilisateurParId((long) ((Math.random() * 5) + 1)), "Manette Xbox Elite Series 2",
+                    "Manette pro personnalisable avec paddles.",
                     CategorieObjet.GAMING, LocalDateTime.now());
             objetRepository.save(objet7);
 
             Objet objet8 = new Objet(
-                    utilisateurService.obtenirUtilisateurParId(8L), "Casque SteelSeries Arctis Pro", "Casque gaming haute fidélité avec son surround.",
+                    utilisateurService.obtenirUtilisateurParId((long) ((Math.random() * 5) + 1)), "Casque SteelSeries Arctis Pro",
+                    "Casque gaming haute fidélité avec son surround.",
                     CategorieObjet.GAMING, LocalDateTime.now());
             objetRepository.save(objet8);
 
             Objet objet9 = new Objet(
-                    utilisateurService.obtenirUtilisateurParId(9L), "Perceuse Bosch GSR 12V", "Perceuse-visseuse sans fil avec batterie lithium-ion.",
+                    utilisateurService.obtenirUtilisateurParId((long) ((Math.random() * 5) + 1)), "Perceuse Bosch GSR 12V",
+                    "Perceuse-visseuse sans fil avec batterie lithium-ion.",
                     CategorieObjet.OUTILS, LocalDateTime.now());
             objetRepository.save(objet9);
 
             Objet objet10 = new Objet(
-                    utilisateurService.obtenirUtilisateurParId(10L), "Timbre Napoléon III 1863", "Timbre rare en bon état, valeur collection.",
+                    utilisateurService.obtenirUtilisateurParId((long) ((Math.random() * 5) + 1)), "Timbre Napoléon III 1863",
+                    "Timbre rare en bon état, valeur collection.",
                     CategorieObjet.COLLECTION, LocalDateTime.now());
             objetRepository.save(objet10);
 
             Objet objet11 = new Objet(
-                    utilisateurService.obtenirUtilisateurParId(11L), "Roman 'Dune' de Frank Herbert", "Édition collector avec couverture rigide.",
+                    utilisateurService.obtenirUtilisateurParId((long) ((Math.random() * 5) + 1)), "Roman 'Dune' de Frank Herbert",
+                    "Édition collector avec couverture rigide.",
                     CategorieObjet.LITTERATURE, LocalDateTime.now());
             objetRepository.save(objet11);
 
             Objet objet12 = new Objet(
-                    utilisateurService.obtenirUtilisateurParId(12L), "Sweat Nike Tech Fleece", "Sweat à capuche gris, taille L.",
+                    utilisateurService.obtenirUtilisateurParId((long) ((Math.random() * 5) + 1)), "Sweat Nike Tech Fleece",
+                    "Sweat à capuche gris, taille L.",
                     CategorieObjet.VETEMENTS, LocalDateTime.now());
             objetRepository.save(objet12);
 
             Objet objet13 = new Objet(
-                    utilisateurService.obtenirUtilisateurParId(13L), "Aspirateur Dyson V11", "Aspirateur sans fil puissant avec station d'accueil.",
+                    utilisateurService.obtenirUtilisateurParId((long) ((Math.random() * 5) + 1)), "Aspirateur Dyson V11",
+                    "Aspirateur sans fil puissant avec station d'accueil.",
                     CategorieObjet.ELECTROMENAGER, LocalDateTime.now());
             objetRepository.save(objet13);
 
             Objet objet14 = new Objet(
-                    utilisateurService.obtenirUtilisateurParId(14L), "Porte-clés Marvel", "Porte-clés en métal avec logo Avengers.",
+                    utilisateurService.obtenirUtilisateurParId((long) ((Math.random() * 5) + 1)), "Porte-clés Marvel",
+                    "Porte-clés en métal avec logo Avengers.",
                     CategorieObjet.AUTRE, LocalDateTime.now());
             objetRepository.save(objet14);
 
             Objet objet15 = new Objet(
-                    utilisateurService.obtenirUtilisateurParId(15L), "Tournevis multifonction Bosch", "Tournevis avec embouts interchangeables.",
+                    utilisateurService.obtenirUtilisateurParId((long) ((Math.random() * 5) + 1)), "Tournevis multifonction Bosch",
+                    "Tournevis avec embouts interchangeables.",
                     CategorieObjet.OUTILS, LocalDateTime.now());
             objetRepository.save(objet15);
 
             Objet objet16 = new Objet(
-                    utilisateurService.obtenirUtilisateurParId(16L), "Console PS5", "Console Sony PlayStation 5 en excellent état.",
+                    utilisateurService.obtenirUtilisateurParId((long) ((Math.random() * 5) + 1)), "Console PS5",
+                    "Console Sony PlayStation 5 en excellent état.",
                     CategorieObjet.GAMING, LocalDateTime.now());
             objetRepository.save(objet16);
 
             Objet objet17 = new Objet(
-                    utilisateurService.obtenirUtilisateurParId(17L), "MacBook Pro M2", "Ordinateur portable Apple, 16 Go RAM, 512 Go SSD.",
+                    utilisateurService.obtenirUtilisateurParId((long) ((Math.random() * 5) + 1)), "MacBook Pro M2",
+                    "Ordinateur portable Apple, 16 Go RAM, 512 Go SSD.",
                     CategorieObjet.INFORMATIQUE, LocalDateTime.now());
             objetRepository.save(objet17);
 
             Objet objet18 = new Objet(
-                    utilisateurService.obtenirUtilisateurParId(18L), "Veste The North Face", "Veste imperméable, idéale pour l'hiver.",
+                    utilisateurService.obtenirUtilisateurParId((long) ((Math.random() * 5) + 1)), "Veste The North Face",
+                    "Veste imperméable, idéale pour l'hiver.",
                     CategorieObjet.VETEMENTS, LocalDateTime.now());
             objetRepository.save(objet18);
 
             Objet objet19 = new Objet(
-                    utilisateurService.obtenirUtilisateurParId(19L), "Machine à café Nespresso Vertuo", "Machine avec capsules compatibles Vertuo.",
+                    utilisateurService.obtenirUtilisateurParId((long) ((Math.random() * 5) + 1)), "Machine à café Nespresso Vertuo",
+                    "Machine avec capsules compatibles Vertuo.",
                     CategorieObjet.ELECTROMENAGER, LocalDateTime.now());
             objetRepository.save(objet19);
 
             Objet objet20 = new Objet(
-                    utilisateurService.obtenirUtilisateurParId(20L), "Lampe Philips Hue", "Lampe connectée avec variation de couleurs.",
+                    utilisateurService.obtenirUtilisateurParId((long) ((Math.random() * 5) + 1)), "Lampe Philips Hue",
+                    "Lampe connectée avec variation de couleurs.",
                     CategorieObjet.MOBILIER, LocalDateTime.now());
             objetRepository.save(objet20);
 
             Objet objet21 = new Objet(
-                    utilisateurService.obtenirUtilisateurParId(21L), "Grille-pain SMEG", "Grille-pain rétro avec thermostat réglable.",
+                    utilisateurService.obtenirUtilisateurParId((long) ((Math.random() * 5) + 1)), "Grille-pain SMEG",
+                    "Grille-pain rétro avec thermostat réglable.",
                     CategorieObjet.ELECTROMENAGER, LocalDateTime.now());
             objetRepository.save(objet21);
 
             Objet objet22 = new Objet(
-                    utilisateurService.obtenirUtilisateurParId(22L), "Tondeuse Husqvarna Automower", "Robot tondeuse autonome.",
+                    utilisateurService.obtenirUtilisateurParId((long) ((Math.random() * 5) + 1)), "Tondeuse Husqvarna Automower",
+                    "Robot tondeuse autonome.",
                     CategorieObjet.JARDINAGE, LocalDateTime.now());
             objetRepository.save(objet22);
 
             Objet objet23 = new Objet(
-                    utilisateurService.obtenirUtilisateurParId(23L), "Préférence d'échange : Roomba", "Aspirateur intelligent recherché en échange.",
+                    utilisateurService.obtenirUtilisateurParId((long) ((Math.random() * 5) + 1)), "Préférence d'échange : Roomba",
+                    "Aspirateur intelligent recherché en échange.",
                     CategorieObjet.AUTRE, LocalDateTime.now());
             objetRepository.save(objet23);
 
             Objet objet24 = new Objet(
-                    utilisateurService.obtenirUtilisateurParId(24L), "Sac à dos Eastpak", "Sac à dos noir, capacité 24L.",
+                    utilisateurService.obtenirUtilisateurParId((long) ((Math.random() * 5) + 1)), "Sac à dos Eastpak",
+                    "Sac à dos noir, capacité 24L.",
                     CategorieObjet.AUTRE, LocalDateTime.now());
             objetRepository.save(objet24);
 
             Objet objet25 = new Objet(
-                    utilisateurService.obtenirUtilisateurParId(25L), "Jeu Zelda: Tears of the Kingdom", "Jeu Nintendo Switch, édition standard.",
+                    utilisateurService.obtenirUtilisateurParId((long) ((Math.random() * 5) + 1)), "Jeu Zelda: Tears of the Kingdom",
+                    "Jeu Nintendo Switch, édition standard.",
                     CategorieObjet.GAMING, LocalDateTime.now());
             objetRepository.save(objet25);
 
             Objet objet26 = new Objet(
-                    utilisateurService.obtenirUtilisateurParId(26L), "Bureau en bois massif", "Bureau spacieux avec tiroirs intégrés.",
+                    utilisateurService.obtenirUtilisateurParId((long) ((Math.random() * 5) + 1)), "Bureau en bois massif",
+                    "Bureau spacieux avec tiroirs intégrés.",
                     CategorieObjet.MOBILIER, LocalDateTime.now());
             objetRepository.save(objet26);
 
             Objet objet27 = new Objet(
-                    utilisateurService.obtenirUtilisateurParId(27L), "Souris Logitech MX Master 3", "Souris sans fil ergonomique pour travail intensif.",
+                    utilisateurService.obtenirUtilisateurParId((long) ((Math.random() * 5) + 1)), "Souris Logitech MX Master 3",
+                    "Souris sans fil ergonomique pour travail intensif.",
                     CategorieObjet.INFORMATIQUE, LocalDateTime.now());
             objetRepository.save(objet27);
 
             Objet objet28 = new Objet(
-                    utilisateurService.obtenirUtilisateurParId(28L), "Livres Harry Potter édition Gallimard", "Collection complète, bon état.",
+                    utilisateurService.obtenirUtilisateurParId((long) ((Math.random() * 5) + 1)), "Livres Harry Potter édition Gallimard",
+                    "Collection complète, bon état.",
                     CategorieObjet.LITTERATURE, LocalDateTime.now());
             objetRepository.save(objet28);
 
             Objet objet29 = new Objet(
-                    utilisateurService.obtenirUtilisateurParId(29L), "Lunettes de soleil Ray-Ban Aviator", "Verres polarisés, monture dorée.",
+                    utilisateurService.obtenirUtilisateurParId((long) ((Math.random() * 5) + 1)), "Lunettes de soleil Ray-Ban Aviator",
+                    "Verres polarisés, monture dorée.",
                     CategorieObjet.AUTRE, LocalDateTime.now());
             objetRepository.save(objet29);
 
             Objet objet30 = new Objet(
-                    utilisateurService.obtenirUtilisateurParId(30L), "Gants de jardinage Wolf-Garten", "Gants résistants pour la taille et plantation.",
+                    utilisateurService.obtenirUtilisateurParId((long) ((Math.random() * 5) + 1)), "Gants de jardinage Wolf-Garten",
+                    "Gants résistants pour la taille et plantation.",
                     CategorieObjet.JARDINAGE, LocalDateTime.now());
             objetRepository.save(objet30);
 
             Echange echange = new Echange(
-                    objetService.obtenirObjetParId(9L), objetService.obtenirObjetParId(3L),
+                    objetService.obtenirObjetParId(9L), objetService.obtenirObjetParId((long) ((Math.random() * 5) + 1)),
                     LocalDateTime.now(), Etat.ATTENTE, null);
             echangeRepository.save(echange);
             Echange echange2 = new Echange(
-                    objetService.obtenirObjetParId(8L), objetService.obtenirObjetParId(5L),
+                    objetService.obtenirObjetParId(8L), objetService.obtenirObjetParId((long) ((Math.random() * 5) + 1)),
                     LocalDateTime.now(), Etat.ACCEPTE, LocalDateTime.now().plusDays(2));
             echangeRepository.save(echange2);
             Echange echange3 = new Echange(
-                    objetService.obtenirObjetParId(10L), objetService.obtenirObjetParId(4L),
+                    objetService.obtenirObjetParId(10L), objetService.obtenirObjetParId((long) ((Math.random() * 5) + 1)),
                     LocalDateTime.now().minusDays(1), Etat.REFUSE, LocalDateTime.now().plusDays(3));
             echangeRepository.save(echange3);
         };
     }
+
+
 }

--- a/Backend/src/main/java/fr/knap/testunitaire_esiee/controller/CredentialsController.java
+++ b/Backend/src/main/java/fr/knap/testunitaire_esiee/controller/CredentialsController.java
@@ -2,7 +2,7 @@ package fr.knap.testunitaire_esiee.controller;
 
 import fr.knap.testunitaire_esiee.model.Credentials;
 import fr.knap.testunitaire_esiee.model.Token;
-import fr.knap.testunitaire_esiee.model.TokenCredential;
+import fr.knap.testunitaire_esiee.dto.TokenCredentialDTO;
 import fr.knap.testunitaire_esiee.model.Utilisateur;
 import fr.knap.testunitaire_esiee.services.UtilisateurService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -27,9 +27,9 @@ public class CredentialsController {
      * @return The token credential for the newly registered user.
      */
     @PostMapping("/register")
-    public TokenCredential creerUtilisateur(@RequestBody Utilisateur utilisateur) {
+    public TokenCredentialDTO creerUtilisateur(@RequestBody Utilisateur utilisateur) {
         utilisateurService.creerUtilisateur(utilisateur);
-        return new TokenCredential(
+        return new TokenCredentialDTO(
                 utilisateurService.login(
                         new Credentials(
                                 utilisateur.getMail(),
@@ -46,10 +46,10 @@ public class CredentialsController {
      * @throws ResponseStatusException if the token is not found.
      */
     @PostMapping("/login")
-    public TokenCredential getConnexionToken(@RequestBody Credentials credentials) {
+    public TokenCredentialDTO getConnexionToken(@RequestBody Credentials credentials) {
         Token token = utilisateurService.login(credentials);
         if (token != null) {
-            return new TokenCredential(token.getToken());
+            return new TokenCredentialDTO(token.getToken());
         } else {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Token not found");
         }
@@ -62,7 +62,7 @@ public class CredentialsController {
      * @throws ResponseStatusException if the token is not valid.
      */
     @PostMapping("/disconnect")
-    public void disconnect(@RequestBody TokenCredential token) {
+    public void disconnect(@RequestBody TokenCredentialDTO token) {
         if (!utilisateurService.verifyToken(token.getToken())) {
             throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Token is not valid");
         }
@@ -77,7 +77,7 @@ public class CredentialsController {
      * @throws ResponseStatusException if the token is invalid.
      */
     @PostMapping("/verifyToken")
-    public void verifyToken(@RequestBody TokenCredential token) {
+    public void verifyToken(@RequestBody TokenCredentialDTO token) {
         if (utilisateurService.verifyToken(token.getToken())) {
             throw new ResponseStatusException(HttpStatus.OK, "Token is valid");
         } else {

--- a/Backend/src/main/java/fr/knap/testunitaire_esiee/controller/EchangeController.java
+++ b/Backend/src/main/java/fr/knap/testunitaire_esiee/controller/EchangeController.java
@@ -50,8 +50,8 @@ public class EchangeController {
      * @return The exchange with the specified ID.
      */
     @GetMapping("/{id}")
-    public Echange obtenirUnEchange(@RequestHeader("Authorization") String authToken,@PathVariable Long id) {
-        if(utilisateurService.verifyToken(authToken))
+    public Echange obtenirUnEchange(@RequestHeader("Authorization") String authToken, @PathVariable Long id) {
+        if (utilisateurService.verifyToken(authToken))
             return echangeService.obtenirEchangeParId(id);
         throw new ResponseStatusException(HttpStatus.FORBIDDEN);
     }
@@ -62,17 +62,17 @@ public class EchangeController {
      * @param echange The exchange to update.
      * @return The updated exchange.
      * @throws IllegalArgumentException if the exchange ID is null.
-     * @throws ResponseStatusException if the exchange does not exist.
+     * @throws ResponseStatusException  if the exchange does not exist.
      */
     @PutMapping("/update")
     public Echange mettreAJourEchange(@RequestHeader("Authorization") String authToken, @RequestBody Echange echange) {
-        if(utilisateurService.verifyToken(authToken)) {
-            if(echange.getId() == null)
+        if (utilisateurService.verifyToken(authToken)) {
+            if (echange.getId() == null)
                 throw new IllegalArgumentException("L'id de l'échange ne peut pas être null");
             if (echangeService.echangeExist(echange.getId()))
                 return echangeService.mettreAJourEchange(echange);
             throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Echange is not valid");
         }
-       throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Token is not valid");
+        throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Token is not valid");
     }
 }

--- a/Backend/src/main/java/fr/knap/testunitaire_esiee/controller/ObjetController.java
+++ b/Backend/src/main/java/fr/knap/testunitaire_esiee/controller/ObjetController.java
@@ -1,7 +1,10 @@
 package fr.knap.testunitaire_esiee.controller;
 
 import fr.knap.testunitaire_esiee.model.Objet;
+import fr.knap.testunitaire_esiee.model.ObjetBuffer;
+import fr.knap.testunitaire_esiee.model.Utilisateur;
 import fr.knap.testunitaire_esiee.services.ObjetService;
+import fr.knap.testunitaire_esiee.services.UtilisateurService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 
@@ -17,6 +20,10 @@ public class ObjetController {
     @Autowired
     private ObjetService objetService;
 
+    @Autowired
+    private UtilisateurService utilisateurService;
+
+
     /**
      * Creates a new object.
      *
@@ -24,7 +31,16 @@ public class ObjetController {
      * @return The created object.
      */
     @PostMapping
-    public Objet creerObjet(@RequestBody Objet objet) {
+    public Objet creerObjet(@RequestHeader("Authorization") String authToken, @RequestBody ObjetBuffer objetBuffer) {
+        Utilisateur utilisateur = utilisateurService.obtenirUtilisateurParToken(authToken);
+
+        Objet objet = new Objet(
+                utilisateur,
+                objetBuffer.getNom(),
+                objetBuffer.getDescription(),
+                objetBuffer.getCategorie(),
+                objetBuffer.getDateCreation()
+        );
         return objetService.creerObjet(objet);
     }
 
@@ -63,7 +79,7 @@ public class ObjetController {
     /**
      * Updates an existing object.
      *
-     * @param id The ID of the object to update.
+     * @param id    The ID of the object to update.
      * @param objet The updated object data.
      * @return The updated object.
      */

--- a/Backend/src/main/java/fr/knap/testunitaire_esiee/controller/ObjetController.java
+++ b/Backend/src/main/java/fr/knap/testunitaire_esiee/controller/ObjetController.java
@@ -26,11 +26,11 @@ public class ObjetController {
     @Autowired
     private UtilisateurService utilisateurService;
 
-
     /**
      * Creates a new object.
      *
-     * @param objet The object to be created.
+     * @param authToken The authorization token of the user.
+     * @param objetBufferDTO The data transfer object containing the details of the object to be created.
      * @return The created object.
      */
     @PostMapping
@@ -62,6 +62,7 @@ public class ObjetController {
     /**
      * Retrieves objects by user ID.
      *
+     * @param authToken The authorization token of the user.
      * @param idUtilisateur The ID of the user whose objects are to be retrieved.
      * @return A list of objects belonging to the specified user.
      */
@@ -86,7 +87,8 @@ public class ObjetController {
     /**
      * Updates an existing object.
      *
-     * @param id    The ID of the object to update.
+     * @param authToken The authorization token of the user.
+     * @param id The ID of the object to update.
      * @param objet The updated object data.
      * @return The updated object.
      */
@@ -100,6 +102,7 @@ public class ObjetController {
     /**
      * Deletes an object by its ID.
      *
+     * @param authToken The authorization token of the user.
      * @param id The ID of the object to delete.
      */
     @DeleteMapping("/{id}")

--- a/Backend/src/main/java/fr/knap/testunitaire_esiee/controller/ObjetController.java
+++ b/Backend/src/main/java/fr/knap/testunitaire_esiee/controller/ObjetController.java
@@ -1,12 +1,15 @@
 package fr.knap.testunitaire_esiee.controller;
 
+import fr.knap.testunitaire_esiee.dto.ObjetDTO;
 import fr.knap.testunitaire_esiee.model.Objet;
-import fr.knap.testunitaire_esiee.model.ObjetBuffer;
+import fr.knap.testunitaire_esiee.dto.ObjetBufferDTO;
 import fr.knap.testunitaire_esiee.model.Utilisateur;
 import fr.knap.testunitaire_esiee.services.ObjetService;
 import fr.knap.testunitaire_esiee.services.UtilisateurService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
 
@@ -31,15 +34,17 @@ public class ObjetController {
      * @return The created object.
      */
     @PostMapping
-    public Objet creerObjet(@RequestHeader("Authorization") String authToken, @RequestBody ObjetBuffer objetBuffer) {
+    public Objet creerObjet(@RequestHeader("Authorization") String authToken, @RequestBody ObjetBufferDTO objetBufferDTO) {
+        if(!utilisateurService.verifyToken(authToken))
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Token is not valid");
         Utilisateur utilisateur = utilisateurService.obtenirUtilisateurParToken(authToken);
 
         Objet objet = new Objet(
                 utilisateur,
-                objetBuffer.getNom(),
-                objetBuffer.getDescription(),
-                objetBuffer.getCategorie(),
-                objetBuffer.getDateCreation()
+                objetBufferDTO.getNom(),
+                objetBufferDTO.getDescription(),
+                objetBufferDTO.getCategorie(),
+                objetBufferDTO.getDateCreation()
         );
         return objetService.creerObjet(objet);
     }
@@ -50,7 +55,7 @@ public class ObjetController {
      * @return A list of all objects.
      */
     @GetMapping
-    public List<Objet> obtenirTousLesObjets() {
+    public List<ObjetDTO> obtenirTousLesObjets() {
         return objetService.obtenirTousLesObjets();
     }
 
@@ -61,8 +66,10 @@ public class ObjetController {
      * @return A list of objects belonging to the specified user.
      */
     @GetMapping("/{idUtilisateur}")
-    public List<Objet> obtenirObjetsParUtilisateur(@PathVariable Long idUtilisateur) {
-        return objetService.obtenirObjetsParUtilisateur(idUtilisateur);
+    public List<ObjetDTO> obtenirObjetsParUtilisateur(@RequestHeader("Authorization") String authToken, @PathVariable Long idUtilisateur) {
+        if(utilisateurService.verifyToken(authToken))
+            return objetService.obtenirObjetsParUtilisateur(idUtilisateur);
+        throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Token is not valid");
     }
 
     /**
@@ -84,8 +91,10 @@ public class ObjetController {
      * @return The updated object.
      */
     @PutMapping("/{id}")
-    public Objet mettreAJourObjet(@PathVariable Long id, @RequestBody Objet objet) {
-        return objetService.mettreAJourObjet(id, objet);
+    public Objet mettreAJourObjet(@RequestHeader("Authorization") String authToken, @PathVariable Long id, @RequestBody Objet objet) {
+        if(utilisateurService.verifyToken(authToken))
+            return objetService.mettreAJourObjet(id, objet);
+        throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Token is not valid");
     }
 
     /**
@@ -94,8 +103,10 @@ public class ObjetController {
      * @param id The ID of the object to delete.
      */
     @DeleteMapping("/{id}")
-    public void supprimerObjet(@PathVariable Long id) {
-        objetService.supprimerObjet(id);
+    public void supprimerObjet(@RequestHeader("Authorization") String authToken, @PathVariable Long id) {
+        if(utilisateurService.verifyToken(authToken))
+            objetService.supprimerObjet(id);
+        throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Token is not valid");
     }
 
 }

--- a/Backend/src/main/java/fr/knap/testunitaire_esiee/controller/ObjetController.java
+++ b/Backend/src/main/java/fr/knap/testunitaire_esiee/controller/ObjetController.java
@@ -107,8 +107,10 @@ public class ObjetController {
      */
     @DeleteMapping("/{id}")
     public void supprimerObjet(@RequestHeader("Authorization") String authToken, @PathVariable Long id) {
-        if(utilisateurService.verifyToken(authToken))
+        if(utilisateurService.verifyToken(authToken)){
             objetService.supprimerObjet(id);
+            throw new ResponseStatusException(HttpStatus.OK, "Object deleted");
+        }
         throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Token is not valid");
     }
 

--- a/Backend/src/main/java/fr/knap/testunitaire_esiee/controller/UtilisateurController.java
+++ b/Backend/src/main/java/fr/knap/testunitaire_esiee/controller/UtilisateurController.java
@@ -5,7 +5,6 @@ import fr.knap.testunitaire_esiee.model.Utilisateur;
 import fr.knap.testunitaire_esiee.services.UtilisateurService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.HttpStatusCode;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
 
@@ -34,12 +33,12 @@ public class UtilisateurController {
     /**
      * Retrieves a specific user by their ID.
      *
-     * @param id The ID of the user to retrieve.
+     * @param authToken The token of the user to retrieve.
      * @return The user with the specified ID.
      */
     @GetMapping("/trans")
     public UtilisateurDTO obtenirUtilisateurInfoParId(@RequestHeader("Authorization") String authToken) {
-        if(utilisateurService.verifyToken(authToken))
+        if (utilisateurService.verifyToken(authToken))
             return utilisateurService.obtenirUtilisateurInfoParToken(authToken);
         throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Token is not valid");
     }
@@ -47,12 +46,13 @@ public class UtilisateurController {
     /**
      * Retrieves a specific user by their ID.
      *
-     * @param id The ID of the user to retrieve.
+     * @param authToken The token of the user to retrieve.
+     * @param id        The ID of the user to retrieve.
      * @return The user with the specified ID.
      */
     @GetMapping("/{id}")
-    public Utilisateur obtenirUtilisateurParId(@RequestHeader("Authorization") String authToken,@PathVariable Long id) {
-        if(utilisateurService.verifyToken(authToken))
+    public Utilisateur obtenirUtilisateurParId(@RequestHeader("Authorization") String authToken, @PathVariable Long id) {
+        if (utilisateurService.verifyToken(authToken))
             return utilisateurService.obtenirUtilisateurParId(id);
         throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Token is not valid");
     }
@@ -60,12 +60,13 @@ public class UtilisateurController {
     /**
      * Retrieves a specific user by their ID.
      *
-     * @param id The ID of the user to retrieve.
+     * @param authToken The token of the user to retrieve.
+     * @param id        The ID of the user to retrieve.
      * @return The user with the specified ID.
      */
     @GetMapping("/pseudo/{id}")
     public UtilisateurDTO obtenirUtilisateurPseudoParId(@RequestHeader("Authorization") String authToken, @PathVariable Long id) {
-        if(utilisateurService.verifyToken(authToken))
+        if (utilisateurService.verifyToken(authToken))
             return utilisateurService.obtenirUtilisateurPseudoParId(id);
         throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Token is not valid");
     }
@@ -73,13 +74,14 @@ public class UtilisateurController {
     /**
      * Updates an existing user.
      *
-     * @param id The ID of the user to update.
+     * @param authToken   The token of the user to update.
+     * @param id          The ID of the user to update.
      * @param utilisateur The updated user data.
      * @return The updated user.
      */
     @PutMapping("/{id}")
     public Utilisateur mettreAJourUtilisateur(@RequestHeader("Authorization") String authToken, @PathVariable Long id, @RequestBody Utilisateur utilisateur) {
-        if(utilisateurService.verifyToken(authToken))
+        if (utilisateurService.verifyToken(authToken))
             return utilisateurService.mettreAJourUtilisateur(id, utilisateur);
         throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Token is not valid");
     }
@@ -87,11 +89,12 @@ public class UtilisateurController {
     /**
      * Deletes a user by their ID.
      *
-     * @param id The ID of the user to delete.
+     * @param authToken The token of the user to delete.
+     * @param id        The ID of the user to delete.
      */
     @DeleteMapping("/{id}")
     public void supprimerUtilisateur(@RequestHeader("Authorization") String authToken, @PathVariable Long id) {
-        if(utilisateurService.verifyToken(authToken))
+        if (utilisateurService.verifyToken(authToken))
             utilisateurService.supprimerUtilisateur(id);
         throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Invalid token");
     }

--- a/Backend/src/main/java/fr/knap/testunitaire_esiee/controller/UtilisateurController.java
+++ b/Backend/src/main/java/fr/knap/testunitaire_esiee/controller/UtilisateurController.java
@@ -94,8 +94,10 @@ public class UtilisateurController {
      */
     @DeleteMapping("/{id}")
     public void supprimerUtilisateur(@RequestHeader("Authorization") String authToken, @PathVariable Long id) {
-        if (utilisateurService.verifyToken(authToken))
+        if (utilisateurService.verifyToken(authToken)){
             utilisateurService.supprimerUtilisateur(id);
+            throw new ResponseStatusException(HttpStatus.OK, "User deleted");
+        }
         throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Invalid token");
     }
 }

--- a/Backend/src/main/java/fr/knap/testunitaire_esiee/controller/UtilisateurController.java
+++ b/Backend/src/main/java/fr/knap/testunitaire_esiee/controller/UtilisateurController.java
@@ -4,7 +4,10 @@ import fr.knap.testunitaire_esiee.dto.UtilisateurDTO;
 import fr.knap.testunitaire_esiee.model.Utilisateur;
 import fr.knap.testunitaire_esiee.services.UtilisateurService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
 
@@ -34,9 +37,11 @@ public class UtilisateurController {
      * @param id The ID of the user to retrieve.
      * @return The user with the specified ID.
      */
-    @GetMapping("/{id}")
-    public UtilisateurDTO obtenirUtilisateurInfoParId(@PathVariable Long id) {
-        return utilisateurService.obtenirUtilisateurInfoParId(id);
+    @GetMapping("/trans")
+    public UtilisateurDTO obtenirUtilisateurInfoParId(@RequestHeader("Authorization") String authToken) {
+        if(utilisateurService.verifyToken(authToken))
+            return utilisateurService.obtenirUtilisateurInfoParToken(authToken);
+        throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Token is not valid");
     }
 
     /**
@@ -46,8 +51,23 @@ public class UtilisateurController {
      * @return The user with the specified ID.
      */
     @GetMapping("/{id}")
-    public UtilisateurDTO obtenirUtilisateurPseudoParId(@PathVariable Long id) {
-        return utilisateurService.obtenirUtilisateurPseudoParId(id);
+    public Utilisateur obtenirUtilisateurParId(@RequestHeader("Authorization") String authToken,@PathVariable Long id) {
+        if(utilisateurService.verifyToken(authToken))
+            return utilisateurService.obtenirUtilisateurParId(id);
+        throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Token is not valid");
+    }
+
+    /**
+     * Retrieves a specific user by their ID.
+     *
+     * @param id The ID of the user to retrieve.
+     * @return The user with the specified ID.
+     */
+    @GetMapping("/pseudo/{id}")
+    public UtilisateurDTO obtenirUtilisateurPseudoParId(@RequestHeader("Authorization") String authToken, @PathVariable Long id) {
+        if(utilisateurService.verifyToken(authToken))
+            return utilisateurService.obtenirUtilisateurPseudoParId(id);
+        throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Token is not valid");
     }
 
     /**
@@ -58,8 +78,10 @@ public class UtilisateurController {
      * @return The updated user.
      */
     @PutMapping("/{id}")
-    public Utilisateur mettreAJourUtilisateur(@PathVariable Long id, @RequestBody Utilisateur utilisateur) {
-        return utilisateurService.mettreAJourUtilisateur(id, utilisateur);
+    public Utilisateur mettreAJourUtilisateur(@RequestHeader("Authorization") String authToken, @PathVariable Long id, @RequestBody Utilisateur utilisateur) {
+        if(utilisateurService.verifyToken(authToken))
+            return utilisateurService.mettreAJourUtilisateur(id, utilisateur);
+        throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Token is not valid");
     }
 
     /**
@@ -68,7 +90,9 @@ public class UtilisateurController {
      * @param id The ID of the user to delete.
      */
     @DeleteMapping("/{id}")
-    public void supprimerUtilisateur(@PathVariable Long id) {
-        utilisateurService.supprimerUtilisateur(id);
+    public void supprimerUtilisateur(@RequestHeader("Authorization") String authToken, @PathVariable Long id) {
+        if(utilisateurService.verifyToken(authToken))
+            utilisateurService.supprimerUtilisateur(id);
+        throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Invalid token");
     }
 }

--- a/Backend/src/main/java/fr/knap/testunitaire_esiee/dto/ObjetBufferDTO.java
+++ b/Backend/src/main/java/fr/knap/testunitaire_esiee/dto/ObjetBufferDTO.java
@@ -9,9 +9,8 @@ import lombok.Setter;
 
 import java.time.LocalDateTime;
 
-
 /**
- * Entity class representing an object.
+ * Data Transfer Object (DTO) representing an object buffer.
  */
 @Getter
 @Setter
@@ -39,8 +38,15 @@ public class ObjetBufferDTO {
     @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
     private LocalDateTime dateCreation;
 
+    /**
+     * Constructs a new ObjetBufferDTO with the specified name, description, category, and creation date.
+     *
+     * @param nom          the name of the object
+     * @param description  the description of the object
+     * @param categorie    the category of the object
+     * @param dateCreation the creation date of the object
+     */
     public ObjetBufferDTO(String nom, String description, CategorieObjet categorie, LocalDateTime dateCreation) {
-
         this.nom = nom;
         this.description = description;
         this.categorie = categorie;

--- a/Backend/src/main/java/fr/knap/testunitaire_esiee/dto/ObjetBufferDTO.java
+++ b/Backend/src/main/java/fr/knap/testunitaire_esiee/dto/ObjetBufferDTO.java
@@ -1,6 +1,7 @@
-package fr.knap.testunitaire_esiee.model;
+package fr.knap.testunitaire_esiee.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import fr.knap.testunitaire_esiee.model.CategorieObjet;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import lombok.Getter;
@@ -14,7 +15,8 @@ import java.time.LocalDateTime;
  */
 @Getter
 @Setter
-public class ObjetBuffer {
+public class ObjetBufferDTO {
+
     /**
      * The name of the object.
      */
@@ -37,7 +39,8 @@ public class ObjetBuffer {
     @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
     private LocalDateTime dateCreation;
 
-    public ObjetBuffer(String nom, String description, CategorieObjet categorie, LocalDateTime dateCreation) {
+    public ObjetBufferDTO(String nom, String description, CategorieObjet categorie, LocalDateTime dateCreation) {
+
         this.nom = nom;
         this.description = description;
         this.categorie = categorie;

--- a/Backend/src/main/java/fr/knap/testunitaire_esiee/dto/ObjetDTO.java
+++ b/Backend/src/main/java/fr/knap/testunitaire_esiee/dto/ObjetDTO.java
@@ -6,16 +6,53 @@ import lombok.Setter;
 
 import java.time.LocalDateTime;
 
+/**
+ * Data Transfer Object (DTO) representing an object.
+ */
 @Getter
 @Setter
 public class ObjetDTO {
+
+    /**
+     * The name of the object.
+     */
     private String nom;
+
+    /**
+     * The description of the object.
+     */
     private String description;
+
+    /**
+     * The category of the object.
+     */
     private CategorieObjet categorie;
+
+    /**
+     * The creation date of the object.
+     */
     private LocalDateTime dateCreation;
+
+    /**
+     * The user associated with the object.
+     */
     private String utilisateur;
+
+    /**
+     * The ID of the user associated with the object.
+     */
     private Long idUtilisateur;
 
+    /**
+     * Constructs a new ObjetDTO with the specified name, description, category, user, user ID, and creation date.
+     *
+     * @param nom           the name of the object
+     * @param description   the description of the object
+     * @param categorie     the category of the object
+     * @param utilisateur   the user associated with the object
+     * @param idUtilisateur the ID of the user associated with the object
+     * @param dateCreation  the creation date of the object
+     */
     public ObjetDTO(String nom, String description, CategorieObjet categorie, String utilisateur, Long idUtilisateur, LocalDateTime dateCreation) {
         this.nom = nom;
         this.description = description;
@@ -23,9 +60,5 @@ public class ObjetDTO {
         this.utilisateur = utilisateur;
         this.idUtilisateur = idUtilisateur;
         this.dateCreation = dateCreation;
-    }
-
-    public ObjetDTO(String nom) {
-        this.nom = nom;
     }
 }

--- a/Backend/src/main/java/fr/knap/testunitaire_esiee/dto/ObjetDTO.java
+++ b/Backend/src/main/java/fr/knap/testunitaire_esiee/dto/ObjetDTO.java
@@ -1,0 +1,31 @@
+package fr.knap.testunitaire_esiee.dto;
+
+import fr.knap.testunitaire_esiee.model.CategorieObjet;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+public class ObjetDTO {
+    private String nom;
+    private String description;
+    private CategorieObjet categorie;
+    private LocalDateTime dateCreation;
+    private String utilisateur;
+    private Long idUtilisateur;
+
+    public ObjetDTO(String nom, String description, CategorieObjet categorie, String utilisateur, Long idUtilisateur, LocalDateTime dateCreation) {
+        this.nom = nom;
+        this.description = description;
+        this.categorie = categorie;
+        this.utilisateur = utilisateur;
+        this.idUtilisateur = idUtilisateur;
+        this.dateCreation = dateCreation;
+    }
+
+    public ObjetDTO(String nom) {
+        this.nom = nom;
+    }
+}

--- a/Backend/src/main/java/fr/knap/testunitaire_esiee/dto/TokenCredentialDTO.java
+++ b/Backend/src/main/java/fr/knap/testunitaire_esiee/dto/TokenCredentialDTO.java
@@ -1,4 +1,4 @@
-package fr.knap.testunitaire_esiee.model;
+package fr.knap.testunitaire_esiee.dto;
 
 import lombok.Getter;
 import lombok.Setter;
@@ -8,7 +8,7 @@ import lombok.Setter;
  */
 @Getter
 @Setter
-public class TokenCredential {
+public class TokenCredentialDTO {
 
     /**
      * The token string.
@@ -20,7 +20,7 @@ public class TokenCredential {
      *
      * @param token The token string.
      */
-    public TokenCredential(String token) {
+    public TokenCredentialDTO(String token) {
         this.token = token;
     }
 

--- a/Backend/src/main/java/fr/knap/testunitaire_esiee/dto/TokenCredentialDTO.java
+++ b/Backend/src/main/java/fr/knap/testunitaire_esiee/dto/TokenCredentialDTO.java
@@ -16,7 +16,7 @@ public class TokenCredentialDTO {
     private String token;
 
     /**
-     * Constructs a new TokenCredential object with the specified token.
+     * Constructs a new TokenCredentialDTO object with the specified token.
      *
      * @param token The token string.
      */

--- a/Backend/src/main/java/fr/knap/testunitaire_esiee/dto/UtilisateurDTO.java
+++ b/Backend/src/main/java/fr/knap/testunitaire_esiee/dto/UtilisateurDTO.java
@@ -3,19 +3,46 @@ package fr.knap.testunitaire_esiee.dto;
 import lombok.Getter;
 import lombok.Setter;
 
+/**
+ * Data Transfer Object (DTO) representing a user.
+ */
 @Getter
 @Setter
 public class UtilisateurDTO {
+
+    /**
+     * The pseudo of the user.
+     */
     private String pseudo;
+
+    /**
+     * The last name of the user.
+     */
     private String nom;
+
+    /**
+     * The first name of the user.
+     */
     private String prenom;
 
+    /**
+     * Constructs a new UtilisateurDTO with the specified pseudo, last name, and first name.
+     *
+     * @param pseudo the pseudo of the user
+     * @param nom the last name of the user
+     * @param prenom the first name of the user
+     */
     public UtilisateurDTO(String pseudo, String nom, String prenom) {
         this.pseudo = pseudo;
         this.nom = nom;
         this.prenom = prenom;
     }
 
+    /**
+     * Constructs a new UtilisateurDTO with the specified pseudo.
+     *
+     * @param pseudo the pseudo of the user
+     */
     public UtilisateurDTO(String pseudo) {
         this.pseudo = pseudo;
     }

--- a/Backend/src/main/java/fr/knap/testunitaire_esiee/dto/UtilisateurDTO.java
+++ b/Backend/src/main/java/fr/knap/testunitaire_esiee/dto/UtilisateurDTO.java
@@ -1,42 +1,22 @@
 package fr.knap.testunitaire_esiee.dto;
 
-    public class UtilisateurDTO {
-        private String pseudo;
-        private String nom;
-        private String prenom;
+import lombok.Getter;
+import lombok.Setter;
 
-        public UtilisateurDTO(String pseudo, String nom, String prenom) {
-            this.pseudo = pseudo;
-            this.nom = nom;
-            this.prenom = prenom;
-        }
+@Getter
+@Setter
+public class UtilisateurDTO {
+    private String pseudo;
+    private String nom;
+    private String prenom;
 
-        public UtilisateurDTO(String pseudo) {
-            this.pseudo = pseudo;
-        }
-
-        // Getters and setters
-        public String getPseudo() {
-            return pseudo;
-        }
-
-        public void setPseudo(String pseudo) {
-            this.pseudo = pseudo;
-        }
-
-        public String getNom() {
-            return nom;
-        }
-
-        public void setNom(String nom) {
-            this.nom = nom;
-        }
-
-        public String getPrenom() {
-            return prenom;
-        }
-
-        public void setPrenom(String prenom) {
-            this.prenom = prenom;
-        }
+    public UtilisateurDTO(String pseudo, String nom, String prenom) {
+        this.pseudo = pseudo;
+        this.nom = nom;
+        this.prenom = prenom;
     }
+
+    public UtilisateurDTO(String pseudo) {
+        this.pseudo = pseudo;
+    }
+}

--- a/Backend/src/main/java/fr/knap/testunitaire_esiee/model/ObjetBuffer.java
+++ b/Backend/src/main/java/fr/knap/testunitaire_esiee/model/ObjetBuffer.java
@@ -1,0 +1,46 @@
+package fr.knap.testunitaire_esiee.model;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+
+/**
+ * Entity class representing an object.
+ */
+@Getter
+@Setter
+public class ObjetBuffer {
+    /**
+     * The name of the object.
+     */
+    private String nom;
+
+    /**
+     * The category of the object.
+     */
+    @Enumerated(EnumType.STRING)
+    private CategorieObjet categorie;
+
+    /**
+     * The description of the object.
+     */
+    private String description;
+
+    /**
+     * The creation date of the object.
+     */
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    private LocalDateTime dateCreation;
+
+    public ObjetBuffer(String nom, String description, CategorieObjet categorie, LocalDateTime dateCreation) {
+        this.nom = nom;
+        this.description = description;
+        this.categorie = categorie;
+        this.dateCreation = dateCreation;
+    }
+}

--- a/Backend/src/main/java/fr/knap/testunitaire_esiee/model/Token.java
+++ b/Backend/src/main/java/fr/knap/testunitaire_esiee/model/Token.java
@@ -1,5 +1,6 @@
 package fr.knap.testunitaire_esiee.model;
 
+import io.jsonwebtoken.JwtBuilder;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
@@ -43,6 +44,11 @@ public class Token {
     private static final Key key = Keys.secretKeyFor(SignatureAlgorithm.HS256);
 
     /**
+     * The separator used to separate the email and password in the token subject.
+     */
+    private static final String separator = "#";
+
+    /**
      * Constructs a new Token object with the specified email and password.
      * Generates a token string and sets the expiration date to 1 hour from the current time.
      *
@@ -52,7 +58,7 @@ public class Token {
     public Token(String mail, String mdp) {
         this.expirationDate = new Date(System.currentTimeMillis() + 3600000); // 1 hour expiration
         this.token = Jwts.builder()
-                .setSubject(mail + mdp)
+                .setSubject(mail + separator + mdp)
                 .setIssuedAt(new Date())
                 .setExpiration(this.expirationDate)
                 .signWith(key)
@@ -97,7 +103,7 @@ public class Token {
      * @return The email of the token.
      */
     public static String getEmail(String token) {
-        return getSubject(token).split(" ")[0];
+        return getSubject(token).split(separator)[0];
     }
 
     /**

--- a/Backend/src/main/java/fr/knap/testunitaire_esiee/model/Token.java
+++ b/Backend/src/main/java/fr/knap/testunitaire_esiee/model/Token.java
@@ -91,6 +91,16 @@ public class Token {
     }
 
     /**
+     * Retrieves the email from the specified token.
+     *
+     * @param token The token from which to retrieve the email.
+     * @return The email of the token.
+     */
+    public static String getEmail(String token) {
+        return getSubject(token).split(" ")[0];
+    }
+
+    /**
      * Disconnects the token by setting its expiration date to the current time.
      */
     public void disconnect() {

--- a/Backend/src/main/java/fr/knap/testunitaire_esiee/repository/ObjetRepository.java
+++ b/Backend/src/main/java/fr/knap/testunitaire_esiee/repository/ObjetRepository.java
@@ -18,4 +18,5 @@ public interface ObjetRepository extends JpaRepository<Objet, Long> {
      * @return A list of objects associated with the specified user ID.
      */
     List<Objet> findByUtilisateurId(Long idUtilisateur);
+
 }

--- a/Backend/src/main/java/fr/knap/testunitaire_esiee/repository/UtilisateurRepository.java
+++ b/Backend/src/main/java/fr/knap/testunitaire_esiee/repository/UtilisateurRepository.java
@@ -21,4 +21,12 @@ public interface UtilisateurRepository extends JpaRepository<Utilisateur, Long> 
      * @return An Optional containing the found Utilisateur, or empty if not found.
      */
     Optional<Utilisateur> findByMailAndMdp(String mail, String mdp);
+
+    /**
+     * Finds a user by email.
+     *
+     * @param mail The email of the user.
+     * @return An Optional containing the found Utilisateur, or empty if not found.
+     */
+    Optional<Utilisateur> findByMail(String mail);
 }

--- a/Backend/src/main/java/fr/knap/testunitaire_esiee/services/ObjetService.java
+++ b/Backend/src/main/java/fr/knap/testunitaire_esiee/services/ObjetService.java
@@ -1,19 +1,29 @@
 package fr.knap.testunitaire_esiee.services;
 
+import fr.knap.testunitaire_esiee.dto.ObjetDTO;
 import fr.knap.testunitaire_esiee.model.Objet;
+import fr.knap.testunitaire_esiee.model.Utilisateur;
 import fr.knap.testunitaire_esiee.repository.ObjetRepository;
+import fr.knap.testunitaire_esiee.repository.UtilisateurRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 /**
  * Service class for managing Objet entities.
  */
 @Service
 public class ObjetService {
+
     @Autowired
     private ObjetRepository objetRepository;
+
+    @Autowired
+    private UtilisateurRepository utilisateurRepository;
 
     /**
      * Creates a new Objet.
@@ -30,8 +40,17 @@ public class ObjetService {
      *
      * @return A list of all Objet entities.
      */
-    public List<Objet> obtenirTousLesObjets() {
-        return objetRepository.findAll();
+    public List<ObjetDTO> obtenirTousLesObjets() {
+        List<Objet> objets = objetRepository.findAll();
+
+        List<ObjetDTO> tousLesObjets = new ArrayList<>();
+
+        objets.forEach(o -> {
+            Utilisateur utilisateur = o.getUtilisateur();
+            tousLesObjets.add(new ObjetDTO(o.getNom(), o.getDescription(), o.getCategorie(), utilisateur.getPseudo(),utilisateur.getId(), o.getDateCreation()));
+        });
+
+        return tousLesObjets;
     }
 
     /**
@@ -47,7 +66,7 @@ public class ObjetService {
     /**
      * Updates an existing Objet entity.
      *
-     * @param id The ID of the Objet entity to be updated.
+     * @param id    The ID of the Objet entity to be updated.
      * @param objet The Objet entity with updated information.
      * @return The updated Objet entity, or null if the entity does not exist.
      */
@@ -73,7 +92,35 @@ public class ObjetService {
      * @param idUtilisateur The ID of the user.
      * @return A list of Objet entities associated with the specified user ID.
      */
-    public List<Objet> obtenirObjetsParUtilisateur(Long idUtilisateur) {
-        return objetRepository.findByUtilisateurId(idUtilisateur);
+    public List<ObjetDTO> obtenirObjetsParUtilisateur(Long idUtilisateur) {
+        Optional<Utilisateur> utilisateur = utilisateurRepository.findById(idUtilisateur);
+
+        if (utilisateur.isPresent()) {
+            Utilisateur u = utilisateur.get();
+            List<Objet> objets = objetRepository.findByUtilisateurId(idUtilisateur);
+            return objets.stream()
+                    .map(o -> new ObjetDTO(o.getNom(), o.getDescription(), o.getCategorie(), u.getPseudo(),u.getId(), o.getDateCreation()))
+                    .collect(Collectors.toList());
+        }
+        return null;
+    }
+
+    /**
+     * Retrieves a list of Objet entities by the user ID.
+     *
+     * @param idUtilisateur The ID of the user.
+     * @return A list of Objet entities associated with the specified user ID.
+     */
+    public ObjetDTO obtenirObjetUnUtilisateur(Long idUtilisateur) {
+        Optional<Utilisateur> utilisateur = utilisateurRepository.findById(idUtilisateur);
+        Optional<Objet> objet = objetRepository.findById(idUtilisateur);
+
+        if (utilisateur.isPresent() && objet.isPresent()) {
+            Utilisateur u = utilisateur.get();
+            Objet o = objet.get();
+
+            return new ObjetDTO(o.getNom(), o.getDescription(), o.getCategorie(), u.getPseudo(),u.getId(), o.getDateCreation());
+        }
+        return null;
     }
 }

--- a/Backend/src/main/java/fr/knap/testunitaire_esiee/services/ObjetService.java
+++ b/Backend/src/main/java/fr/knap/testunitaire_esiee/services/ObjetService.java
@@ -47,7 +47,7 @@ public class ObjetService {
 
         objets.forEach(o -> {
             Utilisateur utilisateur = o.getUtilisateur();
-            tousLesObjets.add(new ObjetDTO(o.getNom(), o.getDescription(), o.getCategorie(), utilisateur.getPseudo(),utilisateur.getId(), o.getDateCreation()));
+            tousLesObjets.add(new ObjetDTO(o.getNom(), o.getDescription(), o.getCategorie(), utilisateur.getPseudo(), utilisateur.getId(), o.getDateCreation()));
         });
 
         return tousLesObjets;
@@ -99,27 +99,8 @@ public class ObjetService {
             Utilisateur u = utilisateur.get();
             List<Objet> objets = objetRepository.findByUtilisateurId(idUtilisateur);
             return objets.stream()
-                    .map(o -> new ObjetDTO(o.getNom(), o.getDescription(), o.getCategorie(), u.getPseudo(),u.getId(), o.getDateCreation()))
+                    .map(o -> new ObjetDTO(o.getNom(), o.getDescription(), o.getCategorie(), u.getPseudo(), u.getId(), o.getDateCreation()))
                     .collect(Collectors.toList());
-        }
-        return null;
-    }
-
-    /**
-     * Retrieves a list of Objet entities by the user ID.
-     *
-     * @param idUtilisateur The ID of the user.
-     * @return A list of Objet entities associated with the specified user ID.
-     */
-    public ObjetDTO obtenirObjetUnUtilisateur(Long idUtilisateur) {
-        Optional<Utilisateur> utilisateur = utilisateurRepository.findById(idUtilisateur);
-        Optional<Objet> objet = objetRepository.findById(idUtilisateur);
-
-        if (utilisateur.isPresent() && objet.isPresent()) {
-            Utilisateur u = utilisateur.get();
-            Objet o = objet.get();
-
-            return new ObjetDTO(o.getNom(), o.getDescription(), o.getCategorie(), u.getPseudo(),u.getId(), o.getDateCreation());
         }
         return null;
     }

--- a/Backend/src/main/java/fr/knap/testunitaire_esiee/services/UtilisateurService.java
+++ b/Backend/src/main/java/fr/knap/testunitaire_esiee/services/UtilisateurService.java
@@ -136,4 +136,29 @@ public class UtilisateurService {
     public void supprimerUtilisateur(Long id) {
         utilisateurRepository.deleteById(id);
     }
+
+    /**
+     * Retrieves a Utilisateur entity by its email.
+     *
+     * @param mail The email of the Utilisateur entity.
+     * @return The Utilisateur entity with the specified email, or null if not found.
+     */
+    public Utilisateur obtenirUtilisateurParMail(String mail) {
+        Optional<Utilisateur> utilisateur = utilisateurRepository.findByMail(mail);
+        return utilisateur.orElse(null);
+    }
+
+    /**
+     * Retrieves a Utilisateur entity by its token.
+     *
+     * @param token The token of the Utilisateur entity.
+     * @return The Utilisateur entity with the specified token, or null if not found.
+     */
+    public Utilisateur obtenirUtilisateurParToken(String token) {
+        Optional<Token> tokenEntity = tokenRepository.findByToken(token);
+        if (tokenEntity.isPresent()) {
+            return obtenirUtilisateurParMail(Token.getEmail(token));
+        }
+        return null;
+    }
 }

--- a/Backend/src/main/java/fr/knap/testunitaire_esiee/services/UtilisateurService.java
+++ b/Backend/src/main/java/fr/knap/testunitaire_esiee/services/UtilisateurService.java
@@ -40,8 +40,6 @@ public class UtilisateurService {
      * @return A list of all Utilisateur entities.
      */
     public List<Utilisateur> obtenirTousLesUtilisateurs() {
-
-
         return utilisateurRepository.findAll();
     }
 
@@ -55,6 +53,12 @@ public class UtilisateurService {
         return utilisateurRepository.findById(id).orElse(null);
     }
 
+    /**
+     * Retrieves a UtilisateurDTO by its ID.
+     *
+     * @param id The ID of the Utilisateur entity.
+     * @return The UtilisateurDTO with the specified ID, or null if not found.
+     */
     public UtilisateurDTO obtenirUtilisateurInfoParId(Long id) {
         Optional<Utilisateur> utilisateur = utilisateurRepository.findById(id);
         if (utilisateur.isPresent()) {
@@ -64,6 +68,12 @@ public class UtilisateurService {
         return null;
     }
 
+    /**
+     * Retrieves a UtilisateurDTO with only the pseudo by its ID.
+     *
+     * @param id The ID of the Utilisateur entity.
+     * @return The UtilisateurDTO with the specified ID, or null if not found.
+     */
     public UtilisateurDTO obtenirUtilisateurPseudoParId(Long id) {
         Optional<Utilisateur> utilisateur = utilisateurRepository.findById(id);
         if (utilisateur.isPresent()) {
@@ -164,10 +174,10 @@ public class UtilisateurService {
     }
 
     /**
-     * Retrieves a Utilisateur entity by its token.
+     * Retrieves a UtilisateurDTO by its token.
      *
      * @param token The token of the Utilisateur entity.
-     * @return The Utilisateur entity with the specified token, or null if not found.
+     * @return The UtilisateurDTO with the specified token, or null if not found.
      */
     public UtilisateurDTO obtenirUtilisateurInfoParToken(String token) {
         Utilisateur u = obtenirUtilisateurParToken(token);

--- a/Backend/src/main/java/fr/knap/testunitaire_esiee/services/UtilisateurService.java
+++ b/Backend/src/main/java/fr/knap/testunitaire_esiee/services/UtilisateurService.java
@@ -63,6 +63,7 @@ public class UtilisateurService {
         }
         return null;
     }
+
     public UtilisateurDTO obtenirUtilisateurPseudoParId(Long id) {
         Optional<Utilisateur> utilisateur = utilisateurRepository.findById(id);
         if (utilisateur.isPresent()) {
@@ -75,7 +76,7 @@ public class UtilisateurService {
     /**
      * Updates an existing Utilisateur entity.
      *
-     * @param id The ID of the Utilisateur entity to be updated.
+     * @param id          The ID of the Utilisateur entity to be updated.
      * @param utilisateur The Utilisateur entity with updated information.
      * @return The updated Utilisateur entity, or null if the entity does not exist.
      */
@@ -160,5 +161,16 @@ public class UtilisateurService {
             return obtenirUtilisateurParMail(Token.getEmail(token));
         }
         return null;
+    }
+
+    /**
+     * Retrieves a Utilisateur entity by its token.
+     *
+     * @param token The token of the Utilisateur entity.
+     * @return The Utilisateur entity with the specified token, or null if not found.
+     */
+    public UtilisateurDTO obtenirUtilisateurInfoParToken(String token) {
+        Utilisateur u = obtenirUtilisateurParToken(token);
+        return new UtilisateurDTO(u.getPseudo(), u.getNom(), u.getPrenom());
     }
 }

--- a/Backend/src/main/java/fr/knap/testunitaire_esiee/services/UtilisateurService.java
+++ b/Backend/src/main/java/fr/knap/testunitaire_esiee/services/UtilisateurService.java
@@ -181,6 +181,9 @@ public class UtilisateurService {
      */
     public UtilisateurDTO obtenirUtilisateurInfoParToken(String token) {
         Utilisateur u = obtenirUtilisateurParToken(token);
+        if (u == null) {
+            return null;
+        }
         return new UtilisateurDTO(u.getPseudo(), u.getNom(), u.getPrenom());
     }
 }

--- a/Backend/src/test/java/fr/knap/testunitaire_esiee/controller/CredentialsControllerTest.java
+++ b/Backend/src/test/java/fr/knap/testunitaire_esiee/controller/CredentialsControllerTest.java
@@ -1,21 +1,22 @@
 package fr.knap.testunitaire_esiee.controller;
 
 import fr.knap.testunitaire_esiee.dto.TokenCredentialDTO;
-import fr.knap.testunitaire_esiee.model.*;
+import fr.knap.testunitaire_esiee.model.Credentials;
+import fr.knap.testunitaire_esiee.model.Token;
+import fr.knap.testunitaire_esiee.model.Utilisateur;
 import fr.knap.testunitaire_esiee.services.UtilisateurService;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.server.ResponseStatusException;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
-/**
- * Unit tests for the CredentialsController class.
- */
+@SpringBootTest
 class CredentialsControllerTest {
 
     @Mock
@@ -24,66 +25,111 @@ class CredentialsControllerTest {
     @InjectMocks
     private CredentialsController credentialsController;
 
-    /**
-     * Sets up the test environment before each test.
-     * Initializes mocks and injects them into the controller.
-     */
-    @BeforeEach
-    void setUp() {
+    public CredentialsControllerTest() {
         MockitoAnnotations.openMocks(this);
     }
 
-    //    TODO: Fix the test
-    //   /**
-    //     * Tests the createUtilisateur method of the CredentialsController.
-    //     * Verifies that a ResponseStatusException is thrown when the user already exists.
-    //     */
-    //    @Test
-    //    void testCreerUtilisateur() {
-    //        Utilisateur utilisateur = new Utilisateur("ddd","test","test@gmail.com","nulle","nulle", new ArrayList<>());
-    //        System.out.println(credentialsController.creerUtilisateur(utilisateur));
-    //        assertTrue(false);
-    //        //assertEquals(TokenCredential.class, credentialsController.creerUtilisateur(utilisateur).getClass());
-    //
-    //    }
-
-    //    TODO: Fix the test
-    //    /**
-    //     * Tests the getConnexionToken method of the CredentialsController.
-    //     * Verifies that a ResponseStatusException is thrown when the credentials are invalid.
-    //     */
-    //    @Test
-    //    void testGetConnexionToken() {
-    //        Credentials credentials = new Credentials("aaaaaa", "aaaa");
-    //        assertEquals(Token.class,credentialsController.getConnexionToken(credentials).getClass());
-    //    }
-
-    /**
-     * Tests the disconnect method of the CredentialsController.
-     * Verifies that a ResponseStatusException is thrown when the token is valid.
-     */
     @Test
-    void testDisconnect() {
-        Token token = new Token("test@mail.com", "password");
-        when(utilisateurService.verifyToken(token.getToken())).thenReturn(true);
-        doNothing().when(utilisateurService).disconnect(token.getToken());
-        assertThrows(
-                ResponseStatusException.class,
-                () -> credentialsController.disconnect(new TokenCredentialDTO(token.getToken()))
-        );
+    void creerUtilisateur_ReturnsTokenCredentialDTO() {
+        Utilisateur utilisateur = new Utilisateur();
+        utilisateur.setMail("user@example.com");
+        utilisateur.setMdp("password");
+        Token token = new Token();
+        token.setToken("sampleToken");
+
+        when(utilisateurService.creerUtilisateur(utilisateur)).thenReturn(utilisateur);
+        when(utilisateurService.login(any(Credentials.class))).thenReturn(token);
+
+        TokenCredentialDTO result = credentialsController.creerUtilisateur(utilisateur);
+
+        assertEquals("sampleToken", result.getToken());
+        verify(utilisateurService, times(1)).creerUtilisateur(utilisateur);
+        verify(utilisateurService, times(1)).login(any(Credentials.class));
     }
 
-    /**
-     * Tests the verifyToken method of the CredentialsController.
-     * Verifies that a ResponseStatusException is thrown when the token is valid.
-     */
     @Test
-    void testVerifyToken() {
-        Token token = new Token("test@mail.com", "password");
-        when(utilisateurService.verifyToken(token.getToken())).thenReturn(true);
-        assertThrows(
-                ResponseStatusException.class,
-                () -> credentialsController.verifyToken(new TokenCredentialDTO(token.getToken()))
-        );
+    void getConnexionToken_ReturnsTokenCredentialDTOIfValid() {
+        Credentials credentials = new Credentials("user@example.com", "password");
+        Token token = new Token();
+        token.setToken("sampleToken");
+
+        when(utilisateurService.login(credentials)).thenReturn(token);
+
+        TokenCredentialDTO result = credentialsController.getConnexionToken(credentials);
+
+        assertEquals("sampleToken", result.getToken());
+        verify(utilisateurService, times(1)).login(credentials);
+    }
+
+    @Test
+    void getConnexionToken_ThrowsExceptionIfInvalid() {
+        Credentials credentials = new Credentials("user@example.com", "wrongpassword");
+
+        when(utilisateurService.login(credentials)).thenReturn(null);
+
+        ResponseStatusException exception = assertThrows(ResponseStatusException.class, () -> {
+            credentialsController.getConnexionToken(credentials);
+        });
+
+        assertEquals(HttpStatus.NOT_FOUND, exception.getStatusCode());
+        verify(utilisateurService, times(1)).login(credentials);
+    }
+
+    @Test
+    void disconnect_InvalidatesTokenIfValid() {
+        TokenCredentialDTO tokenDTO = new TokenCredentialDTO("validToken");
+
+        when(utilisateurService.verifyToken(tokenDTO.getToken())).thenReturn(true);
+
+        ResponseStatusException exception = assertThrows(ResponseStatusException.class, () -> {
+            credentialsController.disconnect(tokenDTO);
+        });
+
+        assertEquals(HttpStatus.OK, exception.getStatusCode());
+        verify(utilisateurService, times(1)).verifyToken(tokenDTO.getToken());
+        verify(utilisateurService, times(1)).disconnect(tokenDTO.getToken());
+    }
+
+    @Test
+    void disconnect_ThrowsExceptionIfInvalid() {
+        TokenCredentialDTO tokenDTO = new TokenCredentialDTO("invalidToken");
+
+        when(utilisateurService.verifyToken(tokenDTO.getToken())).thenReturn(false);
+
+        ResponseStatusException exception = assertThrows(ResponseStatusException.class, () -> {
+            credentialsController.disconnect(tokenDTO);
+        });
+
+        assertEquals(HttpStatus.UNAUTHORIZED, exception.getStatusCode());
+        verify(utilisateurService, times(1)).verifyToken(tokenDTO.getToken());
+        verify(utilisateurService, times(0)).disconnect(tokenDTO.getToken());
+    }
+
+    @Test
+    void verifyToken_ReturnsOkIfValid() {
+        TokenCredentialDTO tokenDTO = new TokenCredentialDTO("validToken");
+
+        when(utilisateurService.verifyToken(tokenDTO.getToken())).thenReturn(true);
+
+        ResponseStatusException exception = assertThrows(ResponseStatusException.class, () -> {
+            credentialsController.verifyToken(tokenDTO);
+        });
+
+        assertEquals(HttpStatus.OK, exception.getStatusCode());
+        verify(utilisateurService, times(1)).verifyToken(tokenDTO.getToken());
+    }
+
+    @Test
+    void verifyToken_ThrowsExceptionIfInvalid() {
+        TokenCredentialDTO tokenDTO = new TokenCredentialDTO("invalidToken");
+
+        when(utilisateurService.verifyToken(tokenDTO.getToken())).thenReturn(false);
+
+        ResponseStatusException exception = assertThrows(ResponseStatusException.class, () -> {
+            credentialsController.verifyToken(tokenDTO);
+        });
+
+        assertEquals(HttpStatus.UNAUTHORIZED, exception.getStatusCode());
+        verify(utilisateurService, times(1)).verifyToken(tokenDTO.getToken());
     }
 }

--- a/Backend/src/test/java/fr/knap/testunitaire_esiee/controller/CredentialsControllerTest.java
+++ b/Backend/src/test/java/fr/knap/testunitaire_esiee/controller/CredentialsControllerTest.java
@@ -1,5 +1,6 @@
 package fr.knap.testunitaire_esiee.controller;
 
+import fr.knap.testunitaire_esiee.dto.TokenCredentialDTO;
 import fr.knap.testunitaire_esiee.model.*;
 import fr.knap.testunitaire_esiee.services.UtilisateurService;
 import org.junit.jupiter.api.BeforeEach;
@@ -68,7 +69,7 @@ class CredentialsControllerTest {
         doNothing().when(utilisateurService).disconnect(token.getToken());
         assertThrows(
                 ResponseStatusException.class,
-                () -> credentialsController.disconnect(new TokenCredential(token.getToken()))
+                () -> credentialsController.disconnect(new TokenCredentialDTO(token.getToken()))
         );
     }
 
@@ -82,7 +83,7 @@ class CredentialsControllerTest {
         when(utilisateurService.verifyToken(token.getToken())).thenReturn(true);
         assertThrows(
                 ResponseStatusException.class,
-                () -> credentialsController.verifyToken(new TokenCredential(token.getToken()))
+                () -> credentialsController.verifyToken(new TokenCredentialDTO(token.getToken()))
         );
     }
 }

--- a/Backend/src/test/java/fr/knap/testunitaire_esiee/controller/CredentialsControllerTest.java
+++ b/Backend/src/test/java/fr/knap/testunitaire_esiee/controller/CredentialsControllerTest.java
@@ -16,6 +16,9 @@ import org.springframework.web.server.ResponseStatusException;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+/**
+ * Unit tests for the CredentialsController class.
+ */
 @SpringBootTest
 class CredentialsControllerTest {
 
@@ -25,10 +28,16 @@ class CredentialsControllerTest {
     @InjectMocks
     private CredentialsController credentialsController;
 
+    /**
+     * Initializes mocks for the test class.
+     */
     public CredentialsControllerTest() {
         MockitoAnnotations.openMocks(this);
     }
 
+    /**
+     * Tests the creerUtilisateur method to ensure it returns a TokenCredentialDTO.
+     */
     @Test
     void creerUtilisateur_ReturnsTokenCredentialDTO() {
         Utilisateur utilisateur = new Utilisateur();
@@ -47,6 +56,9 @@ class CredentialsControllerTest {
         verify(utilisateurService, times(1)).login(any(Credentials.class));
     }
 
+    /**
+     * Tests the getConnexionToken method to ensure it returns a TokenCredentialDTO if credentials are valid.
+     */
     @Test
     void getConnexionToken_ReturnsTokenCredentialDTOIfValid() {
         Credentials credentials = new Credentials("user@example.com", "password");
@@ -61,6 +73,9 @@ class CredentialsControllerTest {
         verify(utilisateurService, times(1)).login(credentials);
     }
 
+    /**
+     * Tests the getConnexionToken method to ensure it throws an exception if credentials are invalid.
+     */
     @Test
     void getConnexionToken_ThrowsExceptionIfInvalid() {
         Credentials credentials = new Credentials("user@example.com", "wrongpassword");
@@ -75,6 +90,9 @@ class CredentialsControllerTest {
         verify(utilisateurService, times(1)).login(credentials);
     }
 
+    /**
+     * Tests the disconnect method to ensure it invalidates the token if it is valid.
+     */
     @Test
     void disconnect_InvalidatesTokenIfValid() {
         TokenCredentialDTO tokenDTO = new TokenCredentialDTO("validToken");
@@ -90,6 +108,9 @@ class CredentialsControllerTest {
         verify(utilisateurService, times(1)).disconnect(tokenDTO.getToken());
     }
 
+    /**
+     * Tests the disconnect method to ensure it throws an exception if the token is invalid.
+     */
     @Test
     void disconnect_ThrowsExceptionIfInvalid() {
         TokenCredentialDTO tokenDTO = new TokenCredentialDTO("invalidToken");
@@ -105,6 +126,9 @@ class CredentialsControllerTest {
         verify(utilisateurService, times(0)).disconnect(tokenDTO.getToken());
     }
 
+    /**
+     * Tests the verifyToken method to ensure it returns OK if the token is valid.
+     */
     @Test
     void verifyToken_ReturnsOkIfValid() {
         TokenCredentialDTO tokenDTO = new TokenCredentialDTO("validToken");
@@ -119,6 +143,9 @@ class CredentialsControllerTest {
         verify(utilisateurService, times(1)).verifyToken(tokenDTO.getToken());
     }
 
+    /**
+     * Tests the verifyToken method to ensure it throws an exception if the token is invalid.
+     */
     @Test
     void verifyToken_ThrowsExceptionIfInvalid() {
         TokenCredentialDTO tokenDTO = new TokenCredentialDTO("invalidToken");

--- a/Backend/src/test/java/fr/knap/testunitaire_esiee/controller/EchangeControllerTest.java
+++ b/Backend/src/test/java/fr/knap/testunitaire_esiee/controller/EchangeControllerTest.java
@@ -17,6 +17,9 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+/**
+ * Unit tests for the EchangeController class.
+ */
 @SpringBootTest
 class EchangeControllerTest {
 
@@ -29,10 +32,16 @@ class EchangeControllerTest {
     @InjectMocks
     private EchangeController echangeController;
 
+    /**
+     * Initializes mocks for the test class.
+     */
     public EchangeControllerTest() {
         MockitoAnnotations.openMocks(this);
     }
 
+    /**
+     * Tests the creerEchange method to ensure it returns the created Echange.
+     */
     @Test
     void creerEchange_ReturnsCreatedEchange() {
         Echange echange = new Echange();
@@ -44,6 +53,9 @@ class EchangeControllerTest {
         verify(echangeService, times(1)).creerEchange(echange);
     }
 
+    /**
+     * Tests the obtenirTousLesEchanges method to ensure it returns all Echanges.
+     */
     @Test
     void obtenirTousLesEchanges_ReturnsAllEchanges() {
         List<Echange> echanges = Arrays.asList(new Echange(), new Echange());
@@ -55,6 +67,9 @@ class EchangeControllerTest {
         verify(echangeService, times(1)).obtenirTousLesEchanges();
     }
 
+    /**
+     * Tests the obtenirUnEchange method to ensure it returns the Echange if the token is valid.
+     */
     @Test
     void obtenirUnEchange_ReturnsEchangeIfTokenValid() {
         Long id = 1L;
@@ -70,6 +85,9 @@ class EchangeControllerTest {
         verify(echangeService, times(1)).obtenirEchangeParId(id);
     }
 
+    /**
+     * Tests the obtenirUnEchange method to ensure it throws a Forbidden exception if the token is invalid.
+     */
     @Test
     void obtenirUnEchange_ThrowsForbiddenIfTokenInvalid() {
         Long id = 1L;
@@ -85,6 +103,9 @@ class EchangeControllerTest {
         verify(echangeService, times(0)).obtenirEchangeParId(id);
     }
 
+    /**
+     * Tests the mettreAJourEchange method to ensure it returns the updated Echange if valid.
+     */
     @Test
     void mettreAJourEchange_ReturnsUpdatedEchangeIfValid() {
         String authToken = "validToken";
@@ -102,6 +123,9 @@ class EchangeControllerTest {
         verify(echangeService, times(1)).mettreAJourEchange(echange);
     }
 
+    /**
+     * Tests the mettreAJourEchange method to ensure it throws an exception if the ID is null.
+     */
     @Test
     void mettreAJourEchange_ThrowsExceptionIfIdNull() {
         String authToken = "validToken";
@@ -118,6 +142,9 @@ class EchangeControllerTest {
         verify(echangeService, times(0)).mettreAJourEchange(any(Echange.class));
     }
 
+    /**
+     * Tests the mettreAJourEchange method to ensure it throws an Unauthorized exception if the Echange does not exist.
+     */
     @Test
     void mettreAJourEchange_ThrowsUnauthorizedIfEchangeNotExist() {
         String authToken = "validToken";
@@ -137,6 +164,9 @@ class EchangeControllerTest {
         verify(echangeService, times(0)).mettreAJourEchange(any(Echange.class));
     }
 
+    /**
+     * Tests the mettreAJourEchange method to ensure it throws a Forbidden exception if the token is invalid.
+     */
     @Test
     void mettreAJourEchange_ThrowsForbiddenIfTokenInvalid() {
         String authToken = "invalidToken";

--- a/Backend/src/test/java/fr/knap/testunitaire_esiee/controller/EchangeControllerTest.java
+++ b/Backend/src/test/java/fr/knap/testunitaire_esiee/controller/EchangeControllerTest.java
@@ -2,55 +2,156 @@ package fr.knap.testunitaire_esiee.controller;
 
 import fr.knap.testunitaire_esiee.model.Echange;
 import fr.knap.testunitaire_esiee.services.EchangeService;
-import org.junit.jupiter.api.BeforeEach;
+import fr.knap.testunitaire_esiee.services.UtilisateurService;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
 
+import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
-/**
- * Unit tests for the EchangeController class.
- */
+@SpringBootTest
 class EchangeControllerTest {
 
     @Mock
     private EchangeService echangeService;
 
+    @Mock
+    private UtilisateurService utilisateurService;
+
     @InjectMocks
     private EchangeController echangeController;
 
-    /**
-     * Sets up the test environment before each test.
-     * Initializes mocks and injects them into the controller.
-     */
-    @BeforeEach
-    void setUp() {
+    public EchangeControllerTest() {
         MockitoAnnotations.openMocks(this);
     }
 
-    /**
-     * Tests the creerEchange method of the EchangeController.
-     * Verifies that the created Echange entity is returned correctly.
-     */
     @Test
-    void testCreerEchange() {
+    void creerEchange_ReturnsCreatedEchange() {
         Echange echange = new Echange();
         when(echangeService.creerEchange(echange)).thenReturn(echange);
-        assertEquals(echange, echangeController.creerEchange(echange));
+
+        Echange result = echangeController.creerEchange(echange);
+
+        assertEquals(echange, result);
+        verify(echangeService, times(1)).creerEchange(echange);
     }
 
-    /**
-     * Tests the obtenirTousLesEchanges method of the EchangeController.
-     * Verifies that the obtenirTousLesEchanges method of the EchangeService is called once.
-     */
     @Test
-    void testObtenirTousLesEchanges() {
-        echangeController.obtenirTousLesEchanges();
+    void obtenirTousLesEchanges_ReturnsAllEchanges() {
+        List<Echange> echanges = Arrays.asList(new Echange(), new Echange());
+        when(echangeService.obtenirTousLesEchanges()).thenReturn(echanges);
+
+        List<Echange> result = echangeController.obtenirTousLesEchanges();
+
+        assertEquals(echanges, result);
         verify(echangeService, times(1)).obtenirTousLesEchanges();
+    }
+
+    @Test
+    void obtenirUnEchange_ReturnsEchangeIfTokenValid() {
+        Long id = 1L;
+        String authToken = "validToken";
+        Echange echange = new Echange();
+        when(utilisateurService.verifyToken(authToken)).thenReturn(true);
+        when(echangeService.obtenirEchangeParId(id)).thenReturn(echange);
+
+        Echange result = echangeController.obtenirUnEchange(authToken, id);
+
+        assertEquals(echange, result);
+        verify(utilisateurService, times(1)).verifyToken(authToken);
+        verify(echangeService, times(1)).obtenirEchangeParId(id);
+    }
+
+    @Test
+    void obtenirUnEchange_ThrowsForbiddenIfTokenInvalid() {
+        Long id = 1L;
+        String authToken = "invalidToken";
+        when(utilisateurService.verifyToken(authToken)).thenReturn(false);
+
+        ResponseStatusException exception = assertThrows(ResponseStatusException.class, () -> {
+            echangeController.obtenirUnEchange(authToken, id);
+        });
+
+        assertEquals(HttpStatus.FORBIDDEN, exception.getStatusCode());
+        verify(utilisateurService, times(1)).verifyToken(authToken);
+        verify(echangeService, times(0)).obtenirEchangeParId(id);
+    }
+
+    @Test
+    void mettreAJourEchange_ReturnsUpdatedEchangeIfValid() {
+        String authToken = "validToken";
+        Echange echange = new Echange();
+        echange.setId(1L);
+        when(utilisateurService.verifyToken(authToken)).thenReturn(true);
+        when(echangeService.echangeExist(echange.getId())).thenReturn(true);
+        when(echangeService.mettreAJourEchange(echange)).thenReturn(echange);
+
+        Echange result = echangeController.mettreAJourEchange(authToken, echange);
+
+        assertEquals(echange, result);
+        verify(utilisateurService, times(1)).verifyToken(authToken);
+        verify(echangeService, times(1)).echangeExist(echange.getId());
+        verify(echangeService, times(1)).mettreAJourEchange(echange);
+    }
+
+    @Test
+    void mettreAJourEchange_ThrowsExceptionIfIdNull() {
+        String authToken = "validToken";
+        Echange echange = new Echange();
+        when(utilisateurService.verifyToken(authToken)).thenReturn(true);
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            echangeController.mettreAJourEchange(authToken, echange);
+        });
+
+        assertEquals("L'id de l'échange ne peut pas être null", exception.getMessage());
+        verify(utilisateurService, times(1)).verifyToken(authToken);
+        verify(echangeService, times(0)).echangeExist(anyLong());
+        verify(echangeService, times(0)).mettreAJourEchange(any(Echange.class));
+    }
+
+    @Test
+    void mettreAJourEchange_ThrowsUnauthorizedIfEchangeNotExist() {
+        String authToken = "validToken";
+        Echange echange = new Echange();
+        echange.setId(1L);
+        when(utilisateurService.verifyToken(authToken)).thenReturn(true);
+        when(echangeService.echangeExist(echange.getId())).thenReturn(false);
+
+        ResponseStatusException exception = assertThrows(ResponseStatusException.class, () -> {
+            echangeController.mettreAJourEchange(authToken, echange);
+        });
+
+        assertEquals(HttpStatus.UNAUTHORIZED, exception.getStatusCode());
+        assertEquals("Echange is not valid", exception.getReason());
+        verify(utilisateurService, times(1)).verifyToken(authToken);
+        verify(echangeService, times(1)).echangeExist(echange.getId());
+        verify(echangeService, times(0)).mettreAJourEchange(any(Echange.class));
+    }
+
+    @Test
+    void mettreAJourEchange_ThrowsForbiddenIfTokenInvalid() {
+        String authToken = "invalidToken";
+        Echange echange = new Echange();
+        echange.setId(1L);
+        when(utilisateurService.verifyToken(authToken)).thenReturn(false);
+
+        ResponseStatusException exception = assertThrows(ResponseStatusException.class, () -> {
+            echangeController.mettreAJourEchange(authToken, echange);
+        });
+
+        assertEquals(HttpStatus.FORBIDDEN, exception.getStatusCode());
+        assertEquals("Token is not valid", exception.getReason());
+        verify(utilisateurService, times(1)).verifyToken(authToken);
+        verify(echangeService, times(0)).echangeExist(anyLong());
+        verify(echangeService, times(0)).mettreAJourEchange(any(Echange.class));
     }
 }

--- a/Backend/src/test/java/fr/knap/testunitaire_esiee/controller/ObjetControllerTest.java
+++ b/Backend/src/test/java/fr/knap/testunitaire_esiee/controller/ObjetControllerTest.java
@@ -22,6 +22,9 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+/**
+ * Unit tests for the ObjetController class.
+ */
 @SpringBootTest
 class ObjetControllerTest {
 
@@ -34,10 +37,16 @@ class ObjetControllerTest {
     @InjectMocks
     private ObjetController objetController;
 
+    /**
+     * Initializes mocks for the test class.
+     */
     public ObjetControllerTest() {
         MockitoAnnotations.openMocks(this);
     }
 
+    /**
+     * Tests the creerObjet method to ensure it returns the created Objet if the token is valid.
+     */
     @Test
     void creerObjet_ReturnsCreatedObjetIfTokenValid() {
         String authToken = "validToken";
@@ -57,6 +66,9 @@ class ObjetControllerTest {
         verify(objetService, times(1)).creerObjet(any(Objet.class));
     }
 
+    /**
+     * Tests the creerObjet method to ensure it throws a Forbidden exception if the token is invalid.
+     */
     @Test
     void creerObjet_ThrowsForbiddenIfTokenInvalid() {
         String authToken = "invalidToken";
@@ -74,6 +86,9 @@ class ObjetControllerTest {
         verify(objetService, times(0)).creerObjet(any(Objet.class));
     }
 
+    /**
+     * Tests the obtenirTousLesObjets method to ensure it returns all Objets.
+     */
     @Test
     void obtenirTousLesObjets_ReturnsAllObjets() {
         List<ObjetDTO> objets = Arrays.asList(
@@ -94,6 +109,9 @@ class ObjetControllerTest {
         verify(objetService, times(1)).obtenirTousLesObjets();
     }
 
+    /**
+     * Tests the obtenirObjetsParUtilisateur method to ensure it returns Objets if the token is valid.
+     */
     @Test
     void obtenirObjetsParUtilisateur_ReturnsObjetsIfTokenValid() {
         String authToken = "validToken";
@@ -119,6 +137,9 @@ class ObjetControllerTest {
         verify(objetService, times(1)).obtenirObjetsParUtilisateur(idUtilisateur);
     }
 
+    /**
+     * Tests the obtenirObjetsParUtilisateur method to ensure it throws a Forbidden exception if the token is invalid.
+     */
     @Test
     void obtenirObjetsParUtilisateur_ThrowsForbiddenIfTokenInvalid() {
         String authToken = "invalidToken";
@@ -135,6 +156,9 @@ class ObjetControllerTest {
         verify(objetService, times(0)).obtenirObjetsParUtilisateur(anyLong());
     }
 
+    /**
+     * Tests the obtenirObjetParId method to ensure it returns the Objet if it exists.
+     */
     @Test
     void obtenirObjetParId_ReturnsObjetIfExists() {
         Long id = 1L;
@@ -147,6 +171,9 @@ class ObjetControllerTest {
         verify(objetService, times(1)).obtenirObjetParId(id);
     }
 
+    /**
+     * Tests the mettreAJourObjet method to ensure it returns the updated Objet if the token is valid.
+     */
     @Test
     void mettreAJourObjet_ReturnsUpdatedObjetIfTokenValid() {
         String authToken = "validToken";
@@ -162,6 +189,9 @@ class ObjetControllerTest {
         verify(objetService, times(1)).mettreAJourObjet(id, objet);
     }
 
+    /**
+     * Tests the mettreAJourObjet method to ensure it throws a Forbidden exception if the token is invalid.
+     */
     @Test
     void mettreAJourObjet_ThrowsForbiddenIfTokenInvalid() {
         String authToken = "invalidToken";
@@ -179,6 +209,9 @@ class ObjetControllerTest {
         verify(objetService, times(0)).mettreAJourObjet(anyLong(), any(Objet.class));
     }
 
+    /**
+     * Tests the supprimerObjet method to ensure it deletes the Objet if the token is valid.
+     */
     @Test
     void supprimerObjet_DeletesObjetIfTokenValid() {
         String authToken = "validToken";
@@ -195,6 +228,9 @@ class ObjetControllerTest {
         verify(objetService, times(1)).supprimerObjet(id);
     }
 
+    /**
+     * Tests the supprimerObjet method to ensure it throws a Forbidden exception if the token is invalid.
+     */
     @Test
     void supprimerObjet_ThrowsForbiddenIfTokenInvalid() {
         String authToken = "invalidToken";

--- a/Backend/src/test/java/fr/knap/testunitaire_esiee/controller/ObjetControllerTest.java
+++ b/Backend/src/test/java/fr/knap/testunitaire_esiee/controller/ObjetControllerTest.java
@@ -1,96 +1,213 @@
 package fr.knap.testunitaire_esiee.controller;
 
+import fr.knap.testunitaire_esiee.dto.ObjetBufferDTO;
+import fr.knap.testunitaire_esiee.dto.ObjetDTO;
+import fr.knap.testunitaire_esiee.model.CategorieObjet;
 import fr.knap.testunitaire_esiee.model.Objet;
+import fr.knap.testunitaire_esiee.model.Utilisateur;
 import fr.knap.testunitaire_esiee.services.ObjetService;
-import org.junit.jupiter.api.BeforeEach;
+import fr.knap.testunitaire_esiee.services.UtilisateurService;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
-/**
- * Unit tests for the ObjetController class.
- */
+@SpringBootTest
 class ObjetControllerTest {
 
     @Mock
     private ObjetService objetService;
 
+    @Mock
+    private UtilisateurService utilisateurService;
+
     @InjectMocks
     private ObjetController objetController;
 
-    /**
-     * Sets up the test environment before each test.
-     * Initializes mocks and injects them into the controller.
-     */
-    @BeforeEach
-    void setUp() {
+    public ObjetControllerTest() {
         MockitoAnnotations.openMocks(this);
     }
 
-    /**
-     * Tests the creerObjet method of the ObjetController.
-     * Verifies that the created Objet entity is returned correctly.
-     */
     @Test
-    void testCreerObjet() {
-        Objet objet = new Objet();
-        when(objetService.creerObjet(objet)).thenReturn(objet);
-        assertEquals(objet, objetController.creerObjet(objet));
+    void creerObjet_ReturnsCreatedObjetIfTokenValid() {
+        String authToken = "validToken";
+        ObjetBufferDTO objetBufferDTO = new ObjetBufferDTO("Laptop", "A high-end gaming laptop", CategorieObjet.INFORMATIQUE, LocalDateTime.now());
+        Utilisateur utilisateur = new Utilisateur();
+        Objet objet = new Objet(utilisateur, "Laptop", "A high-end gaming laptop", CategorieObjet.INFORMATIQUE, LocalDateTime.now());
+
+        when(utilisateurService.verifyToken(authToken)).thenReturn(true);
+        when(utilisateurService.obtenirUtilisateurParToken(authToken)).thenReturn(utilisateur);
+        when(objetService.creerObjet(any(Objet.class))).thenReturn(objet);
+
+        Objet result = objetController.creerObjet(authToken, objetBufferDTO);
+
+        assertEquals(objet, result);
+        verify(utilisateurService, times(1)).verifyToken(authToken);
+        verify(utilisateurService, times(1)).obtenirUtilisateurParToken(authToken);
+        verify(objetService, times(1)).creerObjet(any(Objet.class));
     }
 
-    /**
-     * Tests the obtenirTousLesObjets method of the ObjetController.
-     * Verifies that the obtenirTousLesObjets method of the ObjetService is called once.
-     */
     @Test
-    void testObtenirTousLesObjets() {
-        objetController.obtenirTousLesObjets();
+    void creerObjet_ThrowsForbiddenIfTokenInvalid() {
+        String authToken = "invalidToken";
+        ObjetBufferDTO objetBufferDTO = new ObjetBufferDTO("Laptop", "A high-end gaming laptop", CategorieObjet.INFORMATIQUE, LocalDateTime.now());
+
+        when(utilisateurService.verifyToken(authToken)).thenReturn(false);
+
+        ResponseStatusException exception = assertThrows(ResponseStatusException.class, () -> {
+            objetController.creerObjet(authToken, objetBufferDTO);
+        });
+
+        assertEquals(HttpStatus.FORBIDDEN, exception.getStatusCode());
+        verify(utilisateurService, times(1)).verifyToken(authToken);
+        verify(utilisateurService, times(0)).obtenirUtilisateurParToken(anyString());
+        verify(objetService, times(0)).creerObjet(any(Objet.class));
+    }
+
+    @Test
+    void obtenirTousLesObjets_ReturnsAllObjets() {
+        List<ObjetDTO> objets = Arrays.asList(
+                new ObjetDTO(
+                        "Laptop", "A high-end gaming laptop", CategorieObjet.INFORMATIQUE,
+                        "John Doe", 1L, LocalDateTime.now()
+                ),
+                new ObjetDTO(
+                        "Smartphone", "A high-end smartphone", CategorieObjet.INFORMATIQUE,
+                        "Jane Doe", 2L, LocalDateTime.now()
+                )
+        );
+        when(objetService.obtenirTousLesObjets()).thenReturn(objets);
+
+        List<ObjetDTO> result = objetController.obtenirTousLesObjets();
+
+        assertEquals(objets, result);
         verify(objetService, times(1)).obtenirTousLesObjets();
     }
 
-    /**
-     * Tests the obtenirObjetsParUtilisateur method of the ObjetController.
-     * Verifies that the obtenirObjetsParUtilisateur method of the ObjetService is called once.
-     */
     @Test
-    void testObtenirObjetsParUtilisateur() {
-        objetController.obtenirObjetsParUtilisateur(1L);
-        verify(objetService, times(1)).obtenirObjetsParUtilisateur(1L);
+    void obtenirObjetsParUtilisateur_ReturnsObjetsIfTokenValid() {
+        String authToken = "validToken";
+        Long idUtilisateur = 1L;
+        List<ObjetDTO> objets = Arrays.asList(
+                new ObjetDTO(
+                        "Laptop", "A high-end gaming laptop", CategorieObjet.INFORMATIQUE,
+                        "John Doe", 1L, LocalDateTime.now()
+                ),
+                new ObjetDTO(
+                        "Smartphone", "A high-end smartphone", CategorieObjet.INFORMATIQUE,
+                        "Jane Doe", 2L, LocalDateTime.now()
+                )
+        );
+
+        when(utilisateurService.verifyToken(authToken)).thenReturn(true);
+        when(objetService.obtenirObjetsParUtilisateur(idUtilisateur)).thenReturn(objets);
+
+        List<ObjetDTO> result = objetController.obtenirObjetsParUtilisateur(authToken, idUtilisateur);
+
+        assertEquals(objets, result);
+        verify(utilisateurService, times(1)).verifyToken(authToken);
+        verify(objetService, times(1)).obtenirObjetsParUtilisateur(idUtilisateur);
     }
 
-    /**
-     * Tests the obtenirObjetParId method of the ObjetController.
-     * Verifies that the correct Objet entity is returned for the given ID.
-     */
     @Test
-    void testObtenirObjetParId() {
+    void obtenirObjetsParUtilisateur_ThrowsForbiddenIfTokenInvalid() {
+        String authToken = "invalidToken";
+        Long idUtilisateur = 1L;
+
+        when(utilisateurService.verifyToken(authToken)).thenReturn(false);
+
+        ResponseStatusException exception = assertThrows(ResponseStatusException.class, () -> {
+            objetController.obtenirObjetsParUtilisateur(authToken, idUtilisateur);
+        });
+
+        assertEquals(HttpStatus.FORBIDDEN, exception.getStatusCode());
+        verify(utilisateurService, times(1)).verifyToken(authToken);
+        verify(objetService, times(0)).obtenirObjetsParUtilisateur(anyLong());
+    }
+
+    @Test
+    void obtenirObjetParId_ReturnsObjetIfExists() {
+        Long id = 1L;
         Objet objet = new Objet();
-        when(objetService.obtenirObjetParId(1L)).thenReturn(objet);
-        assertEquals(objet, objetController.obtenirObjetParId(1L));
+        when(objetService.obtenirObjetParId(id)).thenReturn(objet);
+
+        Objet result = objetController.obtenirObjetParId(id);
+
+        assertEquals(objet, result);
+        verify(objetService, times(1)).obtenirObjetParId(id);
     }
 
-    /**
-     * Tests the mettreAJourObjet method of the ObjetController.
-     * Verifies that the updated Objet entity is returned correctly.
-     */
     @Test
-    void testMettreAJourObjet() {
+    void mettreAJourObjet_ReturnsUpdatedObjetIfTokenValid() {
+        String authToken = "validToken";
+        Long id = 1L;
         Objet objet = new Objet();
-        when(objetService.mettreAJourObjet(1L, objet)).thenReturn(objet);
-        assertEquals(objet, objetController.mettreAJourObjet(1L, objet));
+        when(utilisateurService.verifyToken(authToken)).thenReturn(true);
+        when(objetService.mettreAJourObjet(id, objet)).thenReturn(objet);
+
+        Objet result = objetController.mettreAJourObjet(authToken, id, objet);
+
+        assertEquals(objet, result);
+        verify(utilisateurService, times(1)).verifyToken(authToken);
+        verify(objetService, times(1)).mettreAJourObjet(id, objet);
     }
 
-    /**
-     * Tests the supprimerObjet method of the ObjetController.
-     * Verifies that the supprimerObjet method of the ObjetService is called once.
-     */
     @Test
-    void testSupprimerObjet() {
-        objetController.supprimerObjet(1L);
-        verify(objetService, times(1)).supprimerObjet(1L);
+    void mettreAJourObjet_ThrowsForbiddenIfTokenInvalid() {
+        String authToken = "invalidToken";
+        Long id = 1L;
+        Objet objet = new Objet();
+
+        when(utilisateurService.verifyToken(authToken)).thenReturn(false);
+
+        ResponseStatusException exception = assertThrows(ResponseStatusException.class, () -> {
+            objetController.mettreAJourObjet(authToken, id, objet);
+        });
+
+        assertEquals(HttpStatus.FORBIDDEN, exception.getStatusCode());
+        verify(utilisateurService, times(1)).verifyToken(authToken);
+        verify(objetService, times(0)).mettreAJourObjet(anyLong(), any(Objet.class));
+    }
+
+    @Test
+    void supprimerObjet_DeletesObjetIfTokenValid() {
+        String authToken = "validToken";
+        Long id = 1L;
+
+        when(utilisateurService.verifyToken(authToken)).thenReturn(true);
+
+        ResponseStatusException exception = assertThrows(ResponseStatusException.class, () -> {
+            objetController.supprimerObjet(authToken, id);
+        });
+
+        assertEquals(HttpStatus.OK, exception.getStatusCode());
+        verify(utilisateurService, times(1)).verifyToken(authToken);
+        verify(objetService, times(1)).supprimerObjet(id);
+    }
+
+    @Test
+    void supprimerObjet_ThrowsForbiddenIfTokenInvalid() {
+        String authToken = "invalidToken";
+        Long id = 1L;
+
+        when(utilisateurService.verifyToken(authToken)).thenReturn(false);
+
+        ResponseStatusException exception = assertThrows(ResponseStatusException.class, () -> {
+            objetController.supprimerObjet(authToken, id);
+        });
+
+        assertEquals(HttpStatus.FORBIDDEN, exception.getStatusCode());
+        verify(utilisateurService, times(1)).verifyToken(authToken);
+        verify(objetService, times(0)).supprimerObjet(anyLong());
     }
 }

--- a/Backend/src/test/java/fr/knap/testunitaire_esiee/controller/UtilisateurControllerTest.java
+++ b/Backend/src/test/java/fr/knap/testunitaire_esiee/controller/UtilisateurControllerTest.java
@@ -1,21 +1,23 @@
 package fr.knap.testunitaire_esiee.controller;
 
+import fr.knap.testunitaire_esiee.dto.UtilisateurDTO;
 import fr.knap.testunitaire_esiee.model.Utilisateur;
 import fr.knap.testunitaire_esiee.services.UtilisateurService;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
 
+import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
-/**
- * Unit tests for the UtilisateurController class.
- */
+@SpringBootTest
 class UtilisateurControllerTest {
 
     @Mock
@@ -24,54 +26,178 @@ class UtilisateurControllerTest {
     @InjectMocks
     private UtilisateurController utilisateurController;
 
-    /**
-     * Sets up the test environment before each test.
-     * Initializes mocks and injects them into the controller.
-     */
-    @BeforeEach
-    void setUp() {
+    public UtilisateurControllerTest() {
         MockitoAnnotations.openMocks(this);
     }
 
-    /**
-     * Tests the obtenirTousLesUtilisateurs method of the UtilisateurController.
-     * Verifies that the obtenirTousLesUtilisateurs method of the UtilisateurService is called once.
-     */
     @Test
-    void testObtenirTousLesUtilisateurs() {
-        utilisateurController.obtenirTousLesUtilisateurs();
+    void obtenirTousLesUtilisateurs_ReturnsAllUtilisateurs() {
+        List<Utilisateur> utilisateurs = Arrays.asList(new Utilisateur(), new Utilisateur());
+        when(utilisateurService.obtenirTousLesUtilisateurs()).thenReturn(utilisateurs);
+
+        List<Utilisateur> result = utilisateurController.obtenirTousLesUtilisateurs();
+
+        assertEquals(utilisateurs, result);
         verify(utilisateurService, times(1)).obtenirTousLesUtilisateurs();
     }
 
-    /**
-     * Tests the obtenirUtilisateurParId method of the UtilisateurController.
-     * Verifies that the correct Utilisateur entity is returned for the given ID.
-     */
     @Test
-    void testObtenirUtilisateurParId() {
-        Utilisateur utilisateur = new Utilisateur();
-        when(utilisateurService.obtenirUtilisateurParId(1L)).thenReturn(utilisateur);
-        assertEquals(utilisateur, utilisateurController.obtenirUtilisateurInfoParId(1L));
+    void obtenirUtilisateurInfoParId_ReturnsUtilisateurDTOIfTokenValid() {
+        String authToken = "validToken";
+        UtilisateurDTO utilisateurDTO = new UtilisateurDTO(
+                "pseudo",
+                "nom",
+                "prenom"
+        );
+        when(utilisateurService.verifyToken(authToken)).thenReturn(true);
+        when(utilisateurService.obtenirUtilisateurInfoParToken(authToken)).thenReturn(utilisateurDTO);
+
+        UtilisateurDTO result = utilisateurController.obtenirUtilisateurInfoParId(authToken);
+
+        assertEquals(utilisateurDTO, result);
+        verify(utilisateurService, times(1)).verifyToken(authToken);
+        verify(utilisateurService, times(1)).obtenirUtilisateurInfoParToken(authToken);
     }
 
-    /**
-     * Tests the mettreAJourUtilisateur method of the UtilisateurController.
-     * Verifies that the updated Utilisateur entity is returned correctly.
-     */
     @Test
-    void testMettreAJourUtilisateur() {
-        Utilisateur utilisateur = new Utilisateur();
-        when(utilisateurService.mettreAJourUtilisateur(1L, utilisateur)).thenReturn(utilisateur);
-        assertEquals(utilisateur, utilisateurController.mettreAJourUtilisateur(1L, utilisateur));
+    void obtenirUtilisateurInfoParId_ThrowsForbiddenIfTokenInvalid() {
+        String authToken = "invalidToken";
+        when(utilisateurService.verifyToken(authToken)).thenReturn(false);
+
+        ResponseStatusException exception = assertThrows(ResponseStatusException.class, () -> {
+            utilisateurController.obtenirUtilisateurInfoParId(authToken);
+        });
+
+        assertEquals(HttpStatus.FORBIDDEN, exception.getStatusCode());
+        verify(utilisateurService, times(1)).verifyToken(authToken);
+        verify(utilisateurService, times(0)).obtenirUtilisateurInfoParToken(anyString());
     }
 
-    /**
-     * Tests the supprimerUtilisateur method of the UtilisateurController.
-     * Verifies that the supprimerUtilisateur method of the UtilisateurService is called once.
-     */
     @Test
-    void testSupprimerUtilisateur() {
-        utilisateurController.supprimerUtilisateur(1L);
-        verify(utilisateurService, times(1)).supprimerUtilisateur(1L);
+    void obtenirUtilisateurParId_ReturnsUtilisateurIfTokenValid() {
+        String authToken = "validToken";
+        Long id = 1L;
+        Utilisateur utilisateur = new Utilisateur();
+        when(utilisateurService.verifyToken(authToken)).thenReturn(true);
+        when(utilisateurService.obtenirUtilisateurParId(id)).thenReturn(utilisateur);
+
+        Utilisateur result = utilisateurController.obtenirUtilisateurParId(authToken, id);
+
+        assertEquals(utilisateur, result);
+        verify(utilisateurService, times(1)).verifyToken(authToken);
+        verify(utilisateurService, times(1)).obtenirUtilisateurParId(id);
+    }
+
+    @Test
+    void obtenirUtilisateurParId_ThrowsForbiddenIfTokenInvalid() {
+        String authToken = "invalidToken";
+        Long id = 1L;
+        when(utilisateurService.verifyToken(authToken)).thenReturn(false);
+
+        ResponseStatusException exception = assertThrows(ResponseStatusException.class, () -> {
+            utilisateurController.obtenirUtilisateurParId(authToken, id);
+        });
+
+        assertEquals(HttpStatus.FORBIDDEN, exception.getStatusCode());
+        verify(utilisateurService, times(1)).verifyToken(authToken);
+        verify(utilisateurService, times(0)).obtenirUtilisateurParId(anyLong());
+    }
+
+    @Test
+    void obtenirUtilisateurPseudoParId_ReturnsUtilisateurDTOIfTokenValid() {
+        String authToken = "validToken";
+        Long id = 1L;
+        UtilisateurDTO utilisateurDTO = new UtilisateurDTO(
+                "pseudo",
+                "nom",
+                "prenom"
+        );
+        when(utilisateurService.verifyToken(authToken)).thenReturn(true);
+        when(utilisateurService.obtenirUtilisateurPseudoParId(id)).thenReturn(utilisateurDTO);
+
+        UtilisateurDTO result = utilisateurController.obtenirUtilisateurPseudoParId(authToken, id);
+
+        assertEquals(utilisateurDTO, result);
+        verify(utilisateurService, times(1)).verifyToken(authToken);
+        verify(utilisateurService, times(1)).obtenirUtilisateurPseudoParId(id);
+    }
+
+    @Test
+    void obtenirUtilisateurPseudoParId_ThrowsForbiddenIfTokenInvalid() {
+        String authToken = "invalidToken";
+        Long id = 1L;
+        when(utilisateurService.verifyToken(authToken)).thenReturn(false);
+
+        ResponseStatusException exception = assertThrows(ResponseStatusException.class, () -> {
+            utilisateurController.obtenirUtilisateurPseudoParId(authToken, id);
+        });
+
+        assertEquals(HttpStatus.FORBIDDEN, exception.getStatusCode());
+        verify(utilisateurService, times(1)).verifyToken(authToken);
+        verify(utilisateurService, times(0)).obtenirUtilisateurPseudoParId(anyLong());
+    }
+
+    @Test
+    void mettreAJourUtilisateur_ReturnsUpdatedUtilisateurIfTokenValid() {
+        String authToken = "validToken";
+        Long id = 1L;
+        Utilisateur utilisateur = new Utilisateur();
+        when(utilisateurService.verifyToken(authToken)).thenReturn(true);
+        when(utilisateurService.mettreAJourUtilisateur(id, utilisateur)).thenReturn(utilisateur);
+
+        Utilisateur result = utilisateurController.mettreAJourUtilisateur(authToken, id, utilisateur);
+
+        assertEquals(utilisateur, result);
+        verify(utilisateurService, times(1)).verifyToken(authToken);
+        verify(utilisateurService, times(1)).mettreAJourUtilisateur(id, utilisateur);
+    }
+
+    @Test
+    void mettreAJourUtilisateur_ThrowsForbiddenIfTokenInvalid() {
+        String authToken = "invalidToken";
+        Long id = 1L;
+        Utilisateur utilisateur = new Utilisateur();
+
+        when(utilisateurService.verifyToken(authToken)).thenReturn(false);
+
+        ResponseStatusException exception = assertThrows(ResponseStatusException.class, () -> {
+            utilisateurController.mettreAJourUtilisateur(authToken, id, utilisateur);
+        });
+
+        assertEquals(HttpStatus.FORBIDDEN, exception.getStatusCode());
+        verify(utilisateurService, times(1)).verifyToken(authToken);
+        verify(utilisateurService, times(0)).mettreAJourUtilisateur(anyLong(), any(Utilisateur.class));
+    }
+
+    @Test
+    void supprimerUtilisateur_DeletesUtilisateurIfTokenValid() {
+        String authToken = "validToken";
+        Long id = 1L;
+
+        when(utilisateurService.verifyToken(authToken)).thenReturn(true);
+
+        ResponseStatusException exception = assertThrows(ResponseStatusException.class, () -> {
+            utilisateurController.supprimerUtilisateur(authToken, id);
+        });
+
+        assertEquals(HttpStatus.OK, exception.getStatusCode());
+        verify(utilisateurService, times(1)).verifyToken(authToken);
+        verify(utilisateurService, times(1)).supprimerUtilisateur(id);
+    }
+
+    @Test
+    void supprimerUtilisateur_ThrowsForbiddenIfTokenInvalid() {
+        String authToken = "invalidToken";
+        Long id = 1L;
+
+        when(utilisateurService.verifyToken(authToken)).thenReturn(false);
+
+        ResponseStatusException exception = assertThrows(ResponseStatusException.class, () -> {
+            utilisateurController.supprimerUtilisateur(authToken, id);
+        });
+
+        assertEquals(HttpStatus.FORBIDDEN, exception.getStatusCode());
+        verify(utilisateurService, times(1)).verifyToken(authToken);
+        verify(utilisateurService, times(0)).supprimerUtilisateur(anyLong());
     }
 }

--- a/Backend/src/test/java/fr/knap/testunitaire_esiee/controller/UtilisateurControllerTest.java
+++ b/Backend/src/test/java/fr/knap/testunitaire_esiee/controller/UtilisateurControllerTest.java
@@ -17,6 +17,9 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+/**
+ * Unit tests for the UtilisateurController class.
+ */
 @SpringBootTest
 class UtilisateurControllerTest {
 
@@ -26,10 +29,16 @@ class UtilisateurControllerTest {
     @InjectMocks
     private UtilisateurController utilisateurController;
 
+    /**
+     * Initializes mocks for the test class.
+     */
     public UtilisateurControllerTest() {
         MockitoAnnotations.openMocks(this);
     }
 
+    /**
+     * Tests the obtenirTousLesUtilisateurs method to ensure it returns all Utilisateurs.
+     */
     @Test
     void obtenirTousLesUtilisateurs_ReturnsAllUtilisateurs() {
         List<Utilisateur> utilisateurs = Arrays.asList(new Utilisateur(), new Utilisateur());
@@ -41,6 +50,9 @@ class UtilisateurControllerTest {
         verify(utilisateurService, times(1)).obtenirTousLesUtilisateurs();
     }
 
+    /**
+     * Tests the obtenirUtilisateurInfoParId method to ensure it returns UtilisateurDTO if the token is valid.
+     */
     @Test
     void obtenirUtilisateurInfoParId_ReturnsUtilisateurDTOIfTokenValid() {
         String authToken = "validToken";
@@ -59,6 +71,9 @@ class UtilisateurControllerTest {
         verify(utilisateurService, times(1)).obtenirUtilisateurInfoParToken(authToken);
     }
 
+    /**
+     * Tests the obtenirUtilisateurInfoParId method to ensure it throws a Forbidden exception if the token is invalid.
+     */
     @Test
     void obtenirUtilisateurInfoParId_ThrowsForbiddenIfTokenInvalid() {
         String authToken = "invalidToken";
@@ -73,6 +88,9 @@ class UtilisateurControllerTest {
         verify(utilisateurService, times(0)).obtenirUtilisateurInfoParToken(anyString());
     }
 
+    /**
+     * Tests the obtenirUtilisateurParId method to ensure it returns Utilisateur if the token is valid.
+     */
     @Test
     void obtenirUtilisateurParId_ReturnsUtilisateurIfTokenValid() {
         String authToken = "validToken";
@@ -88,6 +106,9 @@ class UtilisateurControllerTest {
         verify(utilisateurService, times(1)).obtenirUtilisateurParId(id);
     }
 
+    /**
+     * Tests the obtenirUtilisateurParId method to ensure it throws a Forbidden exception if the token is invalid.
+     */
     @Test
     void obtenirUtilisateurParId_ThrowsForbiddenIfTokenInvalid() {
         String authToken = "invalidToken";
@@ -103,6 +124,9 @@ class UtilisateurControllerTest {
         verify(utilisateurService, times(0)).obtenirUtilisateurParId(anyLong());
     }
 
+    /**
+     * Tests the obtenirUtilisateurPseudoParId method to ensure it returns UtilisateurDTO if the token is valid.
+     */
     @Test
     void obtenirUtilisateurPseudoParId_ReturnsUtilisateurDTOIfTokenValid() {
         String authToken = "validToken";
@@ -122,6 +146,9 @@ class UtilisateurControllerTest {
         verify(utilisateurService, times(1)).obtenirUtilisateurPseudoParId(id);
     }
 
+    /**
+     * Tests the obtenirUtilisateurPseudoParId method to ensure it throws a Forbidden exception if the token is invalid.
+     */
     @Test
     void obtenirUtilisateurPseudoParId_ThrowsForbiddenIfTokenInvalid() {
         String authToken = "invalidToken";
@@ -137,6 +164,9 @@ class UtilisateurControllerTest {
         verify(utilisateurService, times(0)).obtenirUtilisateurPseudoParId(anyLong());
     }
 
+    /**
+     * Tests the mettreAJourUtilisateur method to ensure it returns the updated Utilisateur if the token is valid.
+     */
     @Test
     void mettreAJourUtilisateur_ReturnsUpdatedUtilisateurIfTokenValid() {
         String authToken = "validToken";
@@ -152,6 +182,9 @@ class UtilisateurControllerTest {
         verify(utilisateurService, times(1)).mettreAJourUtilisateur(id, utilisateur);
     }
 
+    /**
+     * Tests the mettreAJourUtilisateur method to ensure it throws a Forbidden exception if the token is invalid.
+     */
     @Test
     void mettreAJourUtilisateur_ThrowsForbiddenIfTokenInvalid() {
         String authToken = "invalidToken";
@@ -169,6 +202,9 @@ class UtilisateurControllerTest {
         verify(utilisateurService, times(0)).mettreAJourUtilisateur(anyLong(), any(Utilisateur.class));
     }
 
+    /**
+     * Tests the supprimerUtilisateur method to ensure it deletes the Utilisateur if the token is valid.
+     */
     @Test
     void supprimerUtilisateur_DeletesUtilisateurIfTokenValid() {
         String authToken = "validToken";
@@ -185,6 +221,9 @@ class UtilisateurControllerTest {
         verify(utilisateurService, times(1)).supprimerUtilisateur(id);
     }
 
+    /**
+     * Tests the supprimerUtilisateur method to ensure it throws a Forbidden exception if the token is invalid.
+     */
     @Test
     void supprimerUtilisateur_ThrowsForbiddenIfTokenInvalid() {
         String authToken = "invalidToken";

--- a/Backend/src/test/java/fr/knap/testunitaire_esiee/dto/ObjetBufferDTOTest.java
+++ b/Backend/src/test/java/fr/knap/testunitaire_esiee/dto/ObjetBufferDTOTest.java
@@ -5,11 +5,18 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import java.time.LocalDateTime;
+
 import static org.junit.jupiter.api.Assertions.*;
 
+/**
+ * Unit tests for the ObjetBufferDTO class.
+ */
 @SpringBootTest
 class ObjetBufferDTOTest {
 
+    /**
+     * Tests the constructor with parameters to ensure it sets all fields correctly.
+     */
     @Test
     void constructorWithParameters_SetsAllFields() {
         String nom = "Laptop";
@@ -25,6 +32,9 @@ class ObjetBufferDTOTest {
         assertEquals(dateCreation, objetBufferDTO.getDateCreation());
     }
 
+    /**
+     * Tests the setNom method to ensure it updates the nom field.
+     */
     @Test
     void setNom_UpdatesNom() {
         ObjetBufferDTO objetBufferDTO = new ObjetBufferDTO("Laptop", "A high-end gaming laptop", CategorieObjet.INFORMATIQUE, LocalDateTime.now());
@@ -34,6 +44,9 @@ class ObjetBufferDTOTest {
         assertEquals(newNom, objetBufferDTO.getNom());
     }
 
+    /**
+     * Tests the setDescription method to ensure it updates the description field.
+     */
     @Test
     void setDescription_UpdatesDescription() {
         ObjetBufferDTO objetBufferDTO = new ObjetBufferDTO("Laptop", "A high-end gaming laptop", CategorieObjet.INFORMATIQUE, LocalDateTime.now());
@@ -43,6 +56,9 @@ class ObjetBufferDTOTest {
         assertEquals(newDescription, objetBufferDTO.getDescription());
     }
 
+    /**
+     * Tests the setCategorie method to ensure it updates the categorie field.
+     */
     @Test
     void setCategorie_UpdatesCategorie() {
         ObjetBufferDTO objetBufferDTO = new ObjetBufferDTO("Laptop", "A high-end gaming laptop", CategorieObjet.INFORMATIQUE, LocalDateTime.now());
@@ -52,6 +68,9 @@ class ObjetBufferDTOTest {
         assertEquals(newCategorie, objetBufferDTO.getCategorie());
     }
 
+    /**
+     * Tests the setDateCreation method to ensure it updates the dateCreation field.
+     */
     @Test
     void setDateCreation_UpdatesDateCreation() {
         ObjetBufferDTO objetBufferDTO = new ObjetBufferDTO("Laptop", "A high-end gaming laptop", CategorieObjet.INFORMATIQUE, LocalDateTime.now());

--- a/Backend/src/test/java/fr/knap/testunitaire_esiee/dto/ObjetBufferDTOTest.java
+++ b/Backend/src/test/java/fr/knap/testunitaire_esiee/dto/ObjetBufferDTOTest.java
@@ -1,0 +1,63 @@
+package fr.knap.testunitaire_esiee.dto;
+
+import fr.knap.testunitaire_esiee.model.CategorieObjet;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalDateTime;
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class ObjetBufferDTOTest {
+
+    @Test
+    void constructorWithParameters_SetsAllFields() {
+        String nom = "Laptop";
+        String description = "A high-end gaming laptop";
+        CategorieObjet categorie = CategorieObjet.INFORMATIQUE;
+        LocalDateTime dateCreation = LocalDateTime.now();
+
+        ObjetBufferDTO objetBufferDTO = new ObjetBufferDTO(nom, description, categorie, dateCreation);
+
+        assertEquals(nom, objetBufferDTO.getNom());
+        assertEquals(description, objetBufferDTO.getDescription());
+        assertEquals(categorie, objetBufferDTO.getCategorie());
+        assertEquals(dateCreation, objetBufferDTO.getDateCreation());
+    }
+
+    @Test
+    void setNom_UpdatesNom() {
+        ObjetBufferDTO objetBufferDTO = new ObjetBufferDTO("Laptop", "A high-end gaming laptop", CategorieObjet.INFORMATIQUE, LocalDateTime.now());
+        String newNom = "Smartphone";
+        objetBufferDTO.setNom(newNom);
+
+        assertEquals(newNom, objetBufferDTO.getNom());
+    }
+
+    @Test
+    void setDescription_UpdatesDescription() {
+        ObjetBufferDTO objetBufferDTO = new ObjetBufferDTO("Laptop", "A high-end gaming laptop", CategorieObjet.INFORMATIQUE, LocalDateTime.now());
+        String newDescription = "A brand new smartphone";
+        objetBufferDTO.setDescription(newDescription);
+
+        assertEquals(newDescription, objetBufferDTO.getDescription());
+    }
+
+    @Test
+    void setCategorie_UpdatesCategorie() {
+        ObjetBufferDTO objetBufferDTO = new ObjetBufferDTO("Laptop", "A high-end gaming laptop", CategorieObjet.INFORMATIQUE, LocalDateTime.now());
+        CategorieObjet newCategorie = CategorieObjet.ELECTROMENAGER;
+        objetBufferDTO.setCategorie(newCategorie);
+
+        assertEquals(newCategorie, objetBufferDTO.getCategorie());
+    }
+
+    @Test
+    void setDateCreation_UpdatesDateCreation() {
+        ObjetBufferDTO objetBufferDTO = new ObjetBufferDTO("Laptop", "A high-end gaming laptop", CategorieObjet.INFORMATIQUE, LocalDateTime.now());
+        LocalDateTime newDateCreation = LocalDateTime.now().plusDays(1);
+        objetBufferDTO.setDateCreation(newDateCreation);
+
+        assertEquals(newDateCreation, objetBufferDTO.getDateCreation());
+    }
+}

--- a/Backend/src/test/java/fr/knap/testunitaire_esiee/dto/ObjetDTOTest.java
+++ b/Backend/src/test/java/fr/knap/testunitaire_esiee/dto/ObjetDTOTest.java
@@ -5,11 +5,18 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import static org.junit.jupiter.api.Assertions.*;
+
 import java.time.LocalDateTime;
 
+/**
+ * Unit tests for the ObjetDTO class.
+ */
 @SpringBootTest
 class ObjetDTOTest {
 
+    /**
+     * Tests the constructor with parameters to ensure it sets all fields correctly.
+     */
     @Test
     void constructorWithParameters_SetsAllFields() {
         String nom = "Laptop";
@@ -29,6 +36,9 @@ class ObjetDTOTest {
         assertEquals(dateCreation, objetDTO.getDateCreation());
     }
 
+    /**
+     * Tests the setNom method to ensure it updates the nom field.
+     */
     @Test
     void setNom_UpdatesNom() {
         ObjetDTO objetDTO = new ObjetDTO("Laptop", "A high-end gaming laptop", CategorieObjet.INFORMATIQUE, "user123", 1L, LocalDateTime.now());
@@ -38,6 +48,9 @@ class ObjetDTOTest {
         assertEquals(newNom, objetDTO.getNom());
     }
 
+    /**
+     * Tests the setDescription method to ensure it updates the description field.
+     */
     @Test
     void setDescription_UpdatesDescription() {
         ObjetDTO objetDTO = new ObjetDTO("Laptop", "A high-end gaming laptop", CategorieObjet.INFORMATIQUE, "user123", 1L, LocalDateTime.now());
@@ -47,6 +60,9 @@ class ObjetDTOTest {
         assertEquals(newDescription, objetDTO.getDescription());
     }
 
+    /**
+     * Tests the setCategorie method to ensure it updates the categorie field.
+     */
     @Test
     void setCategorie_UpdatesCategorie() {
         ObjetDTO objetDTO = new ObjetDTO("Laptop", "A high-end gaming laptop", CategorieObjet.INFORMATIQUE, "user123", 1L, LocalDateTime.now());
@@ -56,6 +72,9 @@ class ObjetDTOTest {
         assertEquals(newCategorie, objetDTO.getCategorie());
     }
 
+    /**
+     * Tests the setUtilisateur method to ensure it updates the utilisateur field.
+     */
     @Test
     void setUtilisateur_UpdatesUtilisateur() {
         ObjetDTO objetDTO = new ObjetDTO("Laptop", "A high-end gaming laptop", CategorieObjet.INFORMATIQUE, "user123", 1L, LocalDateTime.now());
@@ -65,6 +84,9 @@ class ObjetDTOTest {
         assertEquals(newUtilisateur, objetDTO.getUtilisateur());
     }
 
+    /**
+     * Tests the setIdUtilisateur method to ensure it updates the idUtilisateur field.
+     */
     @Test
     void setIdUtilisateur_UpdatesIdUtilisateur() {
         ObjetDTO objetDTO = new ObjetDTO("Laptop", "A high-end gaming laptop", CategorieObjet.INFORMATIQUE, "user123", 1L, LocalDateTime.now());
@@ -74,6 +96,9 @@ class ObjetDTOTest {
         assertEquals(newIdUtilisateur, objetDTO.getIdUtilisateur());
     }
 
+    /**
+     * Tests the setDateCreation method to ensure it updates the dateCreation field.
+     */
     @Test
     void setDateCreation_UpdatesDateCreation() {
         ObjetDTO objetDTO = new ObjetDTO("Laptop", "A high-end gaming laptop", CategorieObjet.INFORMATIQUE, "user123", 1L, LocalDateTime.now());

--- a/Backend/src/test/java/fr/knap/testunitaire_esiee/dto/ObjetDTOTest.java
+++ b/Backend/src/test/java/fr/knap/testunitaire_esiee/dto/ObjetDTOTest.java
@@ -1,0 +1,85 @@
+package fr.knap.testunitaire_esiee.dto;
+
+import fr.knap.testunitaire_esiee.model.CategorieObjet;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.junit.jupiter.api.Assertions.*;
+import java.time.LocalDateTime;
+
+@SpringBootTest
+class ObjetDTOTest {
+
+    @Test
+    void constructorWithParameters_SetsAllFields() {
+        String nom = "Laptop";
+        String description = "A high-end gaming laptop";
+        CategorieObjet categorie = CategorieObjet.INFORMATIQUE;
+        String utilisateur = "user123";
+        Long idUtilisateur = 1L;
+        LocalDateTime dateCreation = LocalDateTime.now();
+
+        ObjetDTO objetDTO = new ObjetDTO(nom, description, categorie, utilisateur, idUtilisateur, dateCreation);
+
+        assertEquals(nom, objetDTO.getNom());
+        assertEquals(description, objetDTO.getDescription());
+        assertEquals(categorie, objetDTO.getCategorie());
+        assertEquals(utilisateur, objetDTO.getUtilisateur());
+        assertEquals(idUtilisateur, objetDTO.getIdUtilisateur());
+        assertEquals(dateCreation, objetDTO.getDateCreation());
+    }
+
+    @Test
+    void setNom_UpdatesNom() {
+        ObjetDTO objetDTO = new ObjetDTO("Laptop", "A high-end gaming laptop", CategorieObjet.INFORMATIQUE, "user123", 1L, LocalDateTime.now());
+        String newNom = "Smartphone";
+        objetDTO.setNom(newNom);
+
+        assertEquals(newNom, objetDTO.getNom());
+    }
+
+    @Test
+    void setDescription_UpdatesDescription() {
+        ObjetDTO objetDTO = new ObjetDTO("Laptop", "A high-end gaming laptop", CategorieObjet.INFORMATIQUE, "user123", 1L, LocalDateTime.now());
+        String newDescription = "A brand new smartphone";
+        objetDTO.setDescription(newDescription);
+
+        assertEquals(newDescription, objetDTO.getDescription());
+    }
+
+    @Test
+    void setCategorie_UpdatesCategorie() {
+        ObjetDTO objetDTO = new ObjetDTO("Laptop", "A high-end gaming laptop", CategorieObjet.INFORMATIQUE, "user123", 1L, LocalDateTime.now());
+        CategorieObjet newCategorie = CategorieObjet.ELECTROMENAGER;
+        objetDTO.setCategorie(newCategorie);
+
+        assertEquals(newCategorie, objetDTO.getCategorie());
+    }
+
+    @Test
+    void setUtilisateur_UpdatesUtilisateur() {
+        ObjetDTO objetDTO = new ObjetDTO("Laptop", "A high-end gaming laptop", CategorieObjet.INFORMATIQUE, "user123", 1L, LocalDateTime.now());
+        String newUtilisateur = "user456";
+        objetDTO.setUtilisateur(newUtilisateur);
+
+        assertEquals(newUtilisateur, objetDTO.getUtilisateur());
+    }
+
+    @Test
+    void setIdUtilisateur_UpdatesIdUtilisateur() {
+        ObjetDTO objetDTO = new ObjetDTO("Laptop", "A high-end gaming laptop", CategorieObjet.INFORMATIQUE, "user123", 1L, LocalDateTime.now());
+        Long newIdUtilisateur = 2L;
+        objetDTO.setIdUtilisateur(newIdUtilisateur);
+
+        assertEquals(newIdUtilisateur, objetDTO.getIdUtilisateur());
+    }
+
+    @Test
+    void setDateCreation_UpdatesDateCreation() {
+        ObjetDTO objetDTO = new ObjetDTO("Laptop", "A high-end gaming laptop", CategorieObjet.INFORMATIQUE, "user123", 1L, LocalDateTime.now());
+        LocalDateTime newDateCreation = LocalDateTime.now().plusDays(1);
+        objetDTO.setDateCreation(newDateCreation);
+
+        assertEquals(newDateCreation, objetDTO.getDateCreation());
+    }
+}

--- a/Backend/src/test/java/fr/knap/testunitaire_esiee/dto/TokenCredentialDTOTest.java
+++ b/Backend/src/test/java/fr/knap/testunitaire_esiee/dto/TokenCredentialDTOTest.java
@@ -1,0 +1,35 @@
+package fr.knap.testunitaire_esiee.dto;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class TokenCredentialDTOTest {
+
+    @Test
+    void constructorWithParameters_SetsToken() {
+        String token = "sampleToken";
+        TokenCredentialDTO tokenCredentialDTO = new TokenCredentialDTO(token);
+
+        assertEquals(token, tokenCredentialDTO.getToken());
+    }
+
+    @Test
+    void setToken_UpdatesToken() {
+        TokenCredentialDTO tokenCredentialDTO = new TokenCredentialDTO("initialToken");
+        String newToken = "updatedToken";
+        tokenCredentialDTO.setToken(newToken);
+
+        assertEquals(newToken, tokenCredentialDTO.getToken());
+    }
+
+    @Test
+    void getToken_ReturnsToken() {
+        String token = "sampleToken";
+        TokenCredentialDTO tokenCredentialDTO = new TokenCredentialDTO(token);
+
+        assertEquals(token, tokenCredentialDTO.getToken());
+    }
+}

--- a/Backend/src/test/java/fr/knap/testunitaire_esiee/dto/TokenCredentialDTOTest.java
+++ b/Backend/src/test/java/fr/knap/testunitaire_esiee/dto/TokenCredentialDTOTest.java
@@ -5,9 +5,15 @@ import org.springframework.boot.test.context.SpringBootTest;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+/**
+ * Unit tests for the TokenCredentialDTO class.
+ */
 @SpringBootTest
 class TokenCredentialDTOTest {
 
+    /**
+     * Tests the constructor with parameters to ensure it sets the token field correctly.
+     */
     @Test
     void constructorWithParameters_SetsToken() {
         String token = "sampleToken";
@@ -16,6 +22,9 @@ class TokenCredentialDTOTest {
         assertEquals(token, tokenCredentialDTO.getToken());
     }
 
+    /**
+     * Tests the setToken method to ensure it updates the token field.
+     */
     @Test
     void setToken_UpdatesToken() {
         TokenCredentialDTO tokenCredentialDTO = new TokenCredentialDTO("initialToken");
@@ -25,6 +34,9 @@ class TokenCredentialDTOTest {
         assertEquals(newToken, tokenCredentialDTO.getToken());
     }
 
+    /**
+     * Tests the getToken method to ensure it returns the token field.
+     */
     @Test
     void getToken_ReturnsToken() {
         String token = "sampleToken";

--- a/Backend/src/test/java/fr/knap/testunitaire_esiee/dto/UtilisateurDTOTest.java
+++ b/Backend/src/test/java/fr/knap/testunitaire_esiee/dto/UtilisateurDTOTest.java
@@ -1,0 +1,61 @@
+package fr.knap.testunitaire_esiee.dto;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class UtilisateurDTOTest {
+
+    @Test
+    void constructorWithAllParameters_SetsAllFields() {
+        String pseudo = "user123";
+        String nom = "Doe";
+        String prenom = "John";
+
+        UtilisateurDTO utilisateurDTO = new UtilisateurDTO(pseudo, nom, prenom);
+
+        assertEquals(pseudo, utilisateurDTO.getPseudo());
+        assertEquals(nom, utilisateurDTO.getNom());
+        assertEquals(prenom, utilisateurDTO.getPrenom());
+    }
+
+    @Test
+    void constructorWithPseudo_SetsPseudoOnly() {
+        String pseudo = "user123";
+
+        UtilisateurDTO utilisateurDTO = new UtilisateurDTO(pseudo);
+
+        assertEquals(pseudo, utilisateurDTO.getPseudo());
+        assertNull(utilisateurDTO.getNom());
+        assertNull(utilisateurDTO.getPrenom());
+    }
+
+    @Test
+    void setPseudo_UpdatesPseudo() {
+        UtilisateurDTO utilisateurDTO = new UtilisateurDTO("initialPseudo");
+        String newPseudo = "updatedPseudo";
+        utilisateurDTO.setPseudo(newPseudo);
+
+        assertEquals(newPseudo, utilisateurDTO.getPseudo());
+    }
+
+    @Test
+    void setNom_UpdatesNom() {
+        UtilisateurDTO utilisateurDTO = new UtilisateurDTO("user123");
+        String newNom = "Smith";
+        utilisateurDTO.setNom(newNom);
+
+        assertEquals(newNom, utilisateurDTO.getNom());
+    }
+
+    @Test
+    void setPrenom_UpdatesPrenom() {
+        UtilisateurDTO utilisateurDTO = new UtilisateurDTO("user123");
+        String newPrenom = "Jane";
+        utilisateurDTO.setPrenom(newPrenom);
+
+        assertEquals(newPrenom, utilisateurDTO.getPrenom());
+    }
+}

--- a/Backend/src/test/java/fr/knap/testunitaire_esiee/dto/UtilisateurDTOTest.java
+++ b/Backend/src/test/java/fr/knap/testunitaire_esiee/dto/UtilisateurDTOTest.java
@@ -5,9 +5,15 @@ import org.springframework.boot.test.context.SpringBootTest;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+/**
+ * Unit tests for the UtilisateurDTO class.
+ */
 @SpringBootTest
 class UtilisateurDTOTest {
 
+    /**
+     * Tests the constructor with all parameters to ensure it sets all fields correctly.
+     */
     @Test
     void constructorWithAllParameters_SetsAllFields() {
         String pseudo = "user123";
@@ -21,6 +27,9 @@ class UtilisateurDTOTest {
         assertEquals(prenom, utilisateurDTO.getPrenom());
     }
 
+    /**
+     * Tests the constructor with pseudo parameter to ensure it sets the pseudo field only.
+     */
     @Test
     void constructorWithPseudo_SetsPseudoOnly() {
         String pseudo = "user123";
@@ -32,6 +41,9 @@ class UtilisateurDTOTest {
         assertNull(utilisateurDTO.getPrenom());
     }
 
+    /**
+     * Tests the setPseudo method to ensure it updates the pseudo field.
+     */
     @Test
     void setPseudo_UpdatesPseudo() {
         UtilisateurDTO utilisateurDTO = new UtilisateurDTO("initialPseudo");
@@ -41,6 +53,9 @@ class UtilisateurDTOTest {
         assertEquals(newPseudo, utilisateurDTO.getPseudo());
     }
 
+    /**
+     * Tests the setNom method to ensure it updates the nom field.
+     */
     @Test
     void setNom_UpdatesNom() {
         UtilisateurDTO utilisateurDTO = new UtilisateurDTO("user123");
@@ -50,6 +65,9 @@ class UtilisateurDTOTest {
         assertEquals(newNom, utilisateurDTO.getNom());
     }
 
+    /**
+     * Tests the setPrenom method to ensure it updates the prenom field.
+     */
     @Test
     void setPrenom_UpdatesPrenom() {
         UtilisateurDTO utilisateurDTO = new UtilisateurDTO("user123");

--- a/Backend/src/test/java/fr/knap/testunitaire_esiee/model/CategorieObjetTest.java
+++ b/Backend/src/test/java/fr/knap/testunitaire_esiee/model/CategorieObjetTest.java
@@ -1,30 +1,83 @@
 package fr.knap.testunitaire_esiee.model;
 
-import static org.junit.jupiter.api.Assertions.*;
-
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
-/**
- * Unit tests for the CategorieObjet enum.
- */
+import static org.junit.jupiter.api.Assertions.*;
+
 @SpringBootTest
 class CategorieObjetTest {
 
-    /**
-     * Parameterized test for the CategorieObjet enum values.
-     * Verifies that each provided category string corresponds to a valid CategorieObjet enum value.
-     *
-     * @param categorie The category string to be tested.
-     */
-    @ParameterizedTest
-    @ValueSource(strings = {
-            "MOBILIER", "JARDINAGE", "INFORMATIQUE", "GAMING",
-            "OUTILS", "COLLECTION", "LITTERATURE", "VETEMENTS",
-            "ELECTROMENAGER", "AUTRE"
-    })
-    void testCategorieObjetValues(String categorie) {
-        assertNotNull(CategorieObjet.valueOf(categorie));
+    @Test
+    void valueOf_Mobilier() {
+        assertEquals(CategorieObjet.MOBILIER, CategorieObjet.valueOf("MOBILIER"));
+    }
+
+    @Test
+    void valueOf_Jardinage() {
+        assertEquals(CategorieObjet.JARDINAGE, CategorieObjet.valueOf("JARDINAGE"));
+    }
+
+    @Test
+    void valueOf_Informatique() {
+        assertEquals(CategorieObjet.INFORMATIQUE, CategorieObjet.valueOf("INFORMATIQUE"));
+    }
+
+    @Test
+    void valueOf_Gaming() {
+        assertEquals(CategorieObjet.GAMING, CategorieObjet.valueOf("GAMING"));
+    }
+
+    @Test
+    void valueOf_Outils() {
+        assertEquals(CategorieObjet.OUTILS, CategorieObjet.valueOf("OUTILS"));
+    }
+
+    @Test
+    void valueOf_Collection() {
+        assertEquals(CategorieObjet.COLLECTION, CategorieObjet.valueOf("COLLECTION"));
+    }
+
+    @Test
+    void valueOf_Litterature() {
+        assertEquals(CategorieObjet.LITTERATURE, CategorieObjet.valueOf("LITTERATURE"));
+    }
+
+    @Test
+    void valueOf_Vetements() {
+        assertEquals(CategorieObjet.VETEMENTS, CategorieObjet.valueOf("VETEMENTS"));
+    }
+
+    @Test
+    void valueOf_Electromenager() {
+        assertEquals(CategorieObjet.ELECTROMENAGER, CategorieObjet.valueOf("ELECTROMENAGER"));
+    }
+
+    @Test
+    void valueOf_Autre() {
+        assertEquals(CategorieObjet.AUTRE, CategorieObjet.valueOf("AUTRE"));
+    }
+
+    @Test
+    void valueOf_InvalidCategory() {
+        assertThrows(IllegalArgumentException.class, () -> CategorieObjet.valueOf("INVALID"));
+    }
+
+    @Test
+    void values_ContainsAllCategories() {
+        CategorieObjet[] categories = CategorieObjet.values();
+        assertEquals(10, categories.length);
+        assertArrayEquals(new CategorieObjet[]{
+            CategorieObjet.MOBILIER,
+            CategorieObjet.JARDINAGE,
+            CategorieObjet.INFORMATIQUE,
+            CategorieObjet.GAMING,
+            CategorieObjet.OUTILS,
+            CategorieObjet.COLLECTION,
+            CategorieObjet.LITTERATURE,
+            CategorieObjet.VETEMENTS,
+            CategorieObjet.ELECTROMENAGER,
+            CategorieObjet.AUTRE
+        }, categories);
     }
 }

--- a/Backend/src/test/java/fr/knap/testunitaire_esiee/model/CategorieObjetTest.java
+++ b/Backend/src/test/java/fr/knap/testunitaire_esiee/model/CategorieObjetTest.java
@@ -5,79 +5,118 @@ import org.springframework.boot.test.context.SpringBootTest;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+/**
+ * Unit tests for the CategorieObjet enum.
+ */
 @SpringBootTest
 class CategorieObjetTest {
 
+    /**
+     * Tests the valueOf method for the MOBILIER category.
+     */
     @Test
     void valueOf_Mobilier() {
         assertEquals(CategorieObjet.MOBILIER, CategorieObjet.valueOf("MOBILIER"));
     }
 
+    /**
+     * Tests the valueOf method for the JARDINAGE category.
+     */
     @Test
     void valueOf_Jardinage() {
         assertEquals(CategorieObjet.JARDINAGE, CategorieObjet.valueOf("JARDINAGE"));
     }
 
+    /**
+     * Tests the valueOf method for the INFORMATIQUE category.
+     */
     @Test
     void valueOf_Informatique() {
         assertEquals(CategorieObjet.INFORMATIQUE, CategorieObjet.valueOf("INFORMATIQUE"));
     }
 
+    /**
+     * Tests the valueOf method for the GAMING category.
+     */
     @Test
     void valueOf_Gaming() {
         assertEquals(CategorieObjet.GAMING, CategorieObjet.valueOf("GAMING"));
     }
 
+    /**
+     * Tests the valueOf method for the OUTILS category.
+     */
     @Test
     void valueOf_Outils() {
         assertEquals(CategorieObjet.OUTILS, CategorieObjet.valueOf("OUTILS"));
     }
 
+    /**
+     * Tests the valueOf method for the COLLECTION category.
+     */
     @Test
     void valueOf_Collection() {
         assertEquals(CategorieObjet.COLLECTION, CategorieObjet.valueOf("COLLECTION"));
     }
 
+    /**
+     * Tests the valueOf method for the LITTERATURE category.
+     */
     @Test
     void valueOf_Litterature() {
         assertEquals(CategorieObjet.LITTERATURE, CategorieObjet.valueOf("LITTERATURE"));
     }
 
+    /**
+     * Tests the valueOf method for the VETEMENTS category.
+     */
     @Test
     void valueOf_Vetements() {
         assertEquals(CategorieObjet.VETEMENTS, CategorieObjet.valueOf("VETEMENTS"));
     }
 
+    /**
+     * Tests the valueOf method for the ELECTROMENAGER category.
+     */
     @Test
     void valueOf_Electromenager() {
         assertEquals(CategorieObjet.ELECTROMENAGER, CategorieObjet.valueOf("ELECTROMENAGER"));
     }
 
+    /**
+     * Tests the valueOf method for the AUTRE category.
+     */
     @Test
     void valueOf_Autre() {
         assertEquals(CategorieObjet.AUTRE, CategorieObjet.valueOf("AUTRE"));
     }
 
+    /**
+     * Tests the valueOf method for an invalid category.
+     */
     @Test
     void valueOf_InvalidCategory() {
         assertThrows(IllegalArgumentException.class, () -> CategorieObjet.valueOf("INVALID"));
     }
 
+    /**
+     * Tests the values method to ensure it contains all categories.
+     */
     @Test
     void values_ContainsAllCategories() {
         CategorieObjet[] categories = CategorieObjet.values();
         assertEquals(10, categories.length);
         assertArrayEquals(new CategorieObjet[]{
-            CategorieObjet.MOBILIER,
-            CategorieObjet.JARDINAGE,
-            CategorieObjet.INFORMATIQUE,
-            CategorieObjet.GAMING,
-            CategorieObjet.OUTILS,
-            CategorieObjet.COLLECTION,
-            CategorieObjet.LITTERATURE,
-            CategorieObjet.VETEMENTS,
-            CategorieObjet.ELECTROMENAGER,
-            CategorieObjet.AUTRE
+                CategorieObjet.MOBILIER,
+                CategorieObjet.JARDINAGE,
+                CategorieObjet.INFORMATIQUE,
+                CategorieObjet.GAMING,
+                CategorieObjet.OUTILS,
+                CategorieObjet.COLLECTION,
+                CategorieObjet.LITTERATURE,
+                CategorieObjet.VETEMENTS,
+                CategorieObjet.ELECTROMENAGER,
+                CategorieObjet.AUTRE
         }, categories);
     }
 }

--- a/Backend/src/test/java/fr/knap/testunitaire_esiee/model/CredentialsTest.java
+++ b/Backend/src/test/java/fr/knap/testunitaire_esiee/model/CredentialsTest.java
@@ -5,9 +5,15 @@ import org.springframework.boot.test.context.SpringBootTest;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+/**
+ * Unit tests for the Credentials class.
+ */
 @SpringBootTest
 class CredentialsTest {
 
+    /**
+     * Tests the constructor with parameters to ensure it sets the mail and mdp fields correctly.
+     */
     @Test
     void constructorWithParameters_SetsMailAndMdp() {
         Credentials credentials = new Credentials("user@example.com", "password123");
@@ -15,6 +21,9 @@ class CredentialsTest {
         assertEquals("password123", credentials.getMdp());
     }
 
+    /**
+     * Tests the default constructor to ensure it sets the mail and mdp fields to null.
+     */
     @Test
     void defaultConstructor_SetsMailAndMdpToNull() {
         Credentials credentials = new Credentials();
@@ -22,6 +31,9 @@ class CredentialsTest {
         assertNull(credentials.getMdp());
     }
 
+    /**
+     * Tests the setMail method to ensure it updates the mail field.
+     */
     @Test
     void setMail_UpdatesMail() {
         Credentials credentials = new Credentials();
@@ -29,6 +41,9 @@ class CredentialsTest {
         assertEquals("newuser@example.com", credentials.getMail());
     }
 
+    /**
+     * Tests the setMdp method to ensure it updates the mdp field.
+     */
     @Test
     void setMdp_UpdatesMdp() {
         Credentials credentials = new Credentials();

--- a/Backend/src/test/java/fr/knap/testunitaire_esiee/model/CredentialsTest.java
+++ b/Backend/src/test/java/fr/knap/testunitaire_esiee/model/CredentialsTest.java
@@ -1,49 +1,38 @@
 package fr.knap.testunitaire_esiee.model;
 
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-/**
- * Unit tests for the Credentials class.
- */
 @SpringBootTest
 class CredentialsTest {
 
-    private static Credentials credentials;
-    private static Credentials credentials2;
-
-    /**
-     * Sets up the test environment before all tests.
-     * Initializes the Credentials instances with test data.
-     */
-    @BeforeAll
-    static void setUp() {
-        credentials = new Credentials("test@mail.com", "password");
-        credentials2 = new Credentials();
-        credentials2.setMail("test2@mail.com");
-        credentials2.setMdp("password2");
+    @Test
+    void constructorWithParameters_SetsMailAndMdp() {
+        Credentials credentials = new Credentials("user@example.com", "password123");
+        assertEquals("user@example.com", credentials.getMail());
+        assertEquals("password123", credentials.getMdp());
     }
 
-    /**
-     * Tests the getMail method of the Credentials class.
-     * Verifies that the email addresses are returned correctly.
-     */
     @Test
-    void testCredentialsMail() {
-        assertEquals("test@mail.com", credentials.getMail());
-        assertEquals("test2@mail.com", credentials2.getMail());
+    void defaultConstructor_SetsMailAndMdpToNull() {
+        Credentials credentials = new Credentials();
+        assertNull(credentials.getMail());
+        assertNull(credentials.getMdp());
     }
 
-    /**
-     * Tests the getMdp method of the Credentials class.
-     * Verifies that the passwords are returned correctly.
-     */
     @Test
-    void testCredentialsMdp() {
-        assertEquals("password", credentials.getMdp());
-        assertEquals("password2", credentials2.getMdp());
+    void setMail_UpdatesMail() {
+        Credentials credentials = new Credentials();
+        credentials.setMail("newuser@example.com");
+        assertEquals("newuser@example.com", credentials.getMail());
+    }
+
+    @Test
+    void setMdp_UpdatesMdp() {
+        Credentials credentials = new Credentials();
+        credentials.setMdp("newpassword123");
+        assertEquals("newpassword123", credentials.getMdp());
     }
 }

--- a/Backend/src/test/java/fr/knap/testunitaire_esiee/model/EchangeTest.java
+++ b/Backend/src/test/java/fr/knap/testunitaire_esiee/model/EchangeTest.java
@@ -4,11 +4,18 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import java.time.LocalDateTime;
+
 import static org.junit.jupiter.api.Assertions.*;
 
+/**
+ * Unit tests for the Echange class.
+ */
 @SpringBootTest
 class EchangeTest {
 
+    /**
+     * Tests the constructor with parameters to ensure it sets all fields correctly.
+     */
     @Test
     void constructorWithParameters_SetsAllFields() {
         Objet objetPropose = new Objet();
@@ -26,6 +33,9 @@ class EchangeTest {
         assertEquals(dateCloture, echange.getDateCloture());
     }
 
+    /**
+     * Tests the default constructor to ensure it sets all fields to null.
+     */
     @Test
     void defaultConstructor_SetsFieldsToNull() {
         Echange echange = new Echange();
@@ -37,6 +47,9 @@ class EchangeTest {
         assertNull(echange.getDateCloture());
     }
 
+    /**
+     * Tests the setObjetPropose method to ensure it updates the objetPropose field.
+     */
     @Test
     void setObjetPropose_UpdatesObjetPropose() {
         Echange echange = new Echange();
@@ -46,6 +59,9 @@ class EchangeTest {
         assertEquals(objetPropose, echange.getObjetPropose());
     }
 
+    /**
+     * Tests the setObjetDemande method to ensure it updates the objetDemande field.
+     */
     @Test
     void setObjetDemande_UpdatesObjetDemande() {
         Echange echange = new Echange();
@@ -55,6 +71,9 @@ class EchangeTest {
         assertEquals(objetDemande, echange.getObjetDemande());
     }
 
+    /**
+     * Tests the setDateProposition method to ensure it updates the dateProposition field.
+     */
     @Test
     void setDateProposition_UpdatesDateProposition() {
         Echange echange = new Echange();
@@ -64,6 +83,9 @@ class EchangeTest {
         assertEquals(dateProposition, echange.getDateProposition());
     }
 
+    /**
+     * Tests the setEtatEchange method to ensure it updates the etatEchange field.
+     */
     @Test
     void setEtatEchange_UpdatesEtatEchange() {
         Echange echange = new Echange();
@@ -73,6 +95,9 @@ class EchangeTest {
         assertEquals(etatEchange, echange.getEtatEchange());
     }
 
+    /**
+     * Tests the setDateCloture method to ensure it updates the dateCloture field.
+     */
     @Test
     void setDateCloture_UpdatesDateCloture() {
         Echange echange = new Echange();

--- a/Backend/src/test/java/fr/knap/testunitaire_esiee/model/EchangeTest.java
+++ b/Backend/src/test/java/fr/knap/testunitaire_esiee/model/EchangeTest.java
@@ -1,141 +1,84 @@
 package fr.knap.testunitaire_esiee.model;
 
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
+import java.time.LocalDateTime;
 import static org.junit.jupiter.api.Assertions.*;
 
-import java.time.LocalDateTime;
-
-/**
- * Unit tests for the Echange class.
- */
 @SpringBootTest
 class EchangeTest {
 
-    private static Echange echange;
-    private static Echange echange2;
+    @Test
+    void constructorWithParameters_SetsAllFields() {
+        Objet objetPropose = new Objet();
+        Objet objetDemande = new Objet();
+        LocalDateTime dateProposition = LocalDateTime.now();
+        Etat etatEchange = Etat.ATTENTE;
+        LocalDateTime dateCloture = LocalDateTime.now().plusDays(1);
 
-    /**
-     * Sets up the test environment before all tests.
-     * Initializes the Echange instances with test data.
-     */
-    @BeforeAll
-    static void setUp() {
-        echange = new Echange();
-        echange.setId(1L);
-        echange.setObjetPropose(new Objet());
-        echange.setObjetDemande(new Objet());
-        echange.setDateProposition(LocalDateTime.now());
-        echange.setEtatEchange(Etat.ATTENTE);
-        echange.setDateCloture(LocalDateTime.now());
+        Echange echange = new Echange(objetPropose, objetDemande, dateProposition, etatEchange, dateCloture);
 
-        echange2 = new Echange(
-                new Objet(),
-                new Objet(),
-                LocalDateTime.now(),
-                Etat.ATTENTE,
-                LocalDateTime.now()
-        );
+        assertEquals(objetPropose, echange.getObjetPropose());
+        assertEquals(objetDemande, echange.getObjetDemande());
+        assertEquals(dateProposition, echange.getDateProposition());
+        assertEquals(etatEchange, echange.getEtatEchange());
+        assertEquals(dateCloture, echange.getDateCloture());
     }
 
-    /**
-     * Tests the setId method of the Echange class.
-     * Verifies that the ID is set correctly.
-     */
     @Test
-    void testSetId() {
-        assertEquals(1L, echange.getId());
+    void defaultConstructor_SetsFieldsToNull() {
+        Echange echange = new Echange();
+
+        assertNull(echange.getObjetPropose());
+        assertNull(echange.getObjetDemande());
+        assertNull(echange.getDateProposition());
+        assertNull(echange.getEtatEchange());
+        assertNull(echange.getDateCloture());
     }
 
-    /**
-     * Tests the setDateProposition method of the Echange class.
-     * Verifies that the date of proposition is set correctly.
-     */
     @Test
-    void testSetDateProposition() {
-        assertNotNull(echange.getDateProposition());
+    void setObjetPropose_UpdatesObjetPropose() {
+        Echange echange = new Echange();
+        Objet objetPropose = new Objet();
+        echange.setObjetPropose(objetPropose);
+
+        assertEquals(objetPropose, echange.getObjetPropose());
     }
 
-    /**
-     * Tests the setEtatEchange method of the Echange class.
-     * Verifies that the state of the exchange is set correctly.
-     */
     @Test
-    void testSetEtatEchange() {
-        assertEquals(Etat.ATTENTE, echange.getEtatEchange());
+    void setObjetDemande_UpdatesObjetDemande() {
+        Echange echange = new Echange();
+        Objet objetDemande = new Objet();
+        echange.setObjetDemande(objetDemande);
+
+        assertEquals(objetDemande, echange.getObjetDemande());
     }
 
-    /**
-     * Tests the setDateCloture method of the Echange class.
-     * Verifies that the date of closure is set correctly.
-     */
     @Test
-    void testSetDateCloture() {
-        assertNotNull(echange.getDateCloture());
+    void setDateProposition_UpdatesDateProposition() {
+        Echange echange = new Echange();
+        LocalDateTime dateProposition = LocalDateTime.now();
+        echange.setDateProposition(dateProposition);
+
+        assertEquals(dateProposition, echange.getDateProposition());
     }
 
-    /**
-     * Tests the setObjetPropose method of the Echange class.
-     * Verifies that the proposed object is set correctly.
-     */
     @Test
-    void testSetObjetPropose() {
-        assertNotNull(echange.getObjetPropose());
+    void setEtatEchange_UpdatesEtatEchange() {
+        Echange echange = new Echange();
+        Etat etatEchange = Etat.ATTENTE;
+        echange.setEtatEchange(etatEchange);
+
+        assertEquals(etatEchange, echange.getEtatEchange());
     }
 
-    /**
-     * Tests the setObjetDemande method of the Echange class.
-     * Verifies that the requested object is set correctly.
-     */
     @Test
-    void testSetObjetDemande() {
-        assertNotNull(echange.getObjetDemande());
-    }
+    void setDateCloture_UpdatesDateCloture() {
+        Echange echange = new Echange();
+        LocalDateTime dateCloture = LocalDateTime.now().plusDays(1);
+        echange.setDateCloture(dateCloture);
 
-    /**
-     * Tests the setDateProposition method of the second Echange instance.
-     * Verifies that the date of proposition is set correctly.
-     */
-    @Test
-    void testSetDateProposition2() {
-        assertNotNull(echange2.getDateProposition());
-    }
-
-    /**
-     * Tests the setEtatEchange method of the second Echange instance.
-     * Verifies that the state of the exchange is set correctly.
-     */
-    @Test
-    void testSetEtatEchange2() {
-        assertEquals(Etat.ATTENTE, echange2.getEtatEchange());
-    }
-
-    /**
-     * Tests the setDateCloture method of the second Echange instance.
-     * Verifies that the date of closure is set correctly.
-     */
-    @Test
-    void testSetDateCloture2() {
-        assertNotNull(echange2.getDateCloture());
-    }
-
-    /**
-     * Tests the setObjetPropose method of the second Echange instance.
-     * Verifies that the proposed object is set correctly.
-     */
-    @Test
-    void testSetObjetPropose2() {
-        assertNotNull(echange2.getObjetPropose());
-    }
-
-    /**
-     * Tests the setObjetDemande method of the second Echange instance.
-     * Verifies that the requested object is set correctly.
-     */
-    @Test
-    void testSetObjetDemande2() {
-        assertNotNull(echange2.getObjetDemande());
+        assertEquals(dateCloture, echange.getDateCloture());
     }
 }

--- a/Backend/src/test/java/fr/knap/testunitaire_esiee/model/EtatTest.java
+++ b/Backend/src/test/java/fr/knap/testunitaire_esiee/model/EtatTest.java
@@ -5,43 +5,64 @@ import org.springframework.boot.test.context.SpringBootTest;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+/**
+ * Unit tests for the Etat enum.
+ */
 @SpringBootTest
 class EtatTest {
 
+    /**
+     * Tests the valueOf method for the ATTENTE state.
+     */
     @Test
     void valueOf_Attente() {
         assertEquals(Etat.ATTENTE, Etat.valueOf("ATTENTE"));
     }
 
+    /**
+     * Tests the valueOf method for the ACCEPTE state.
+     */
     @Test
     void valueOf_Accepte() {
         assertEquals(Etat.ACCEPTE, Etat.valueOf("ACCEPTE"));
     }
 
+    /**
+     * Tests the valueOf method for the REFUSE state.
+     */
     @Test
     void valueOf_Refuse() {
         assertEquals(Etat.REFUSE, Etat.valueOf("REFUSE"));
     }
 
+    /**
+     * Tests the valueOf method for the ANNULER state.
+     */
     @Test
     void valueOf_Annuler() {
         assertEquals(Etat.ANNULER, Etat.valueOf("ANNULER"));
     }
 
+    /**
+     * Tests the valueOf method for an invalid state.
+     */
     @Test
     void valueOf_InvalidState() {
         assertThrows(IllegalArgumentException.class, () -> Etat.valueOf("INVALID"));
     }
 
+    /**
+     * Tests the values method to ensure it contains all states.
+     */
     @Test
     void values_ContainsAllStates() {
         Etat[] states = Etat.values();
         assertEquals(4, states.length);
         assertArrayEquals(new Etat[]{
-            Etat.ATTENTE,
-            Etat.ACCEPTE,
-            Etat.REFUSE,
-            Etat.ANNULER
+                Etat.ATTENTE,
+                Etat.ACCEPTE,
+                Etat.REFUSE,
+                Etat.ANNULER
         }, states);
     }
 }

--- a/Backend/src/test/java/fr/knap/testunitaire_esiee/model/EtatTest.java
+++ b/Backend/src/test/java/fr/knap/testunitaire_esiee/model/EtatTest.java
@@ -1,26 +1,47 @@
 package fr.knap.testunitaire_esiee.model;
 
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-/**
- * Unit tests for the Etat enum.
- */
 @SpringBootTest
 class EtatTest {
 
-    /**
-     * Parameterized test for the Etat enum values.
-     * Verifies that each provided state string corresponds to a valid Etat enum value.
-     *
-     * @param etat The state string to be tested.
-     */
-    @ParameterizedTest
-    @ValueSource(strings = {"ATTENTE", "ACCEPTE", "REFUSE", "ANNULER"})
-    void testEtatValues(String etat) {
-        assertNotNull(Etat.valueOf(etat));
+    @Test
+    void valueOf_Attente() {
+        assertEquals(Etat.ATTENTE, Etat.valueOf("ATTENTE"));
+    }
+
+    @Test
+    void valueOf_Accepte() {
+        assertEquals(Etat.ACCEPTE, Etat.valueOf("ACCEPTE"));
+    }
+
+    @Test
+    void valueOf_Refuse() {
+        assertEquals(Etat.REFUSE, Etat.valueOf("REFUSE"));
+    }
+
+    @Test
+    void valueOf_Annuler() {
+        assertEquals(Etat.ANNULER, Etat.valueOf("ANNULER"));
+    }
+
+    @Test
+    void valueOf_InvalidState() {
+        assertThrows(IllegalArgumentException.class, () -> Etat.valueOf("INVALID"));
+    }
+
+    @Test
+    void values_ContainsAllStates() {
+        Etat[] states = Etat.values();
+        assertEquals(4, states.length);
+        assertArrayEquals(new Etat[]{
+            Etat.ATTENTE,
+            Etat.ACCEPTE,
+            Etat.REFUSE,
+            Etat.ANNULER
+        }, states);
     }
 }

--- a/Backend/src/test/java/fr/knap/testunitaire_esiee/model/ObjetTest.java
+++ b/Backend/src/test/java/fr/knap/testunitaire_esiee/model/ObjetTest.java
@@ -1,140 +1,84 @@
 package fr.knap.testunitaire_esiee.model;
 
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
+import java.time.LocalDateTime;
 import static org.junit.jupiter.api.Assertions.*;
 
-import java.time.LocalDateTime;
-
-/**
- * Unit tests for the Objet class.
- */
 @SpringBootTest
 class ObjetTest {
 
-    private static Objet objet;
-    private static Objet objet2;
+    @Test
+    void constructorWithParameters_SetsAllFields() {
+        Utilisateur utilisateur = new Utilisateur();
+        String nom = "Laptop";
+        String description = "A high-end gaming laptop";
+        CategorieObjet categorie = CategorieObjet.INFORMATIQUE;
+        LocalDateTime dateCreation = LocalDateTime.now();
 
-    /**
-     * Sets up the test environment before all tests.
-     * Initializes the Objet instances with test data.
-     */
-    @BeforeAll
-    static void setUp() {
-        objet = new Objet();
-        objet.setId(1L);
-        objet.setNom("Test Objet");
-        objet.setCategorie(CategorieObjet.INFORMATIQUE);
-        objet.setDescription("Description de test");
-        objet.setDateCreation(LocalDateTime.now());
+        Objet objet = new Objet(utilisateur, nom, description, categorie, dateCreation);
 
-        objet2 = new Objet(
-                null,
-                "Test Objet 2",
-                "Description de test 2",
-                CategorieObjet.INFORMATIQUE,
-                LocalDateTime.now()
-        );
+        assertEquals(utilisateur, objet.getUtilisateur());
+        assertEquals(nom, objet.getNom());
+        assertEquals(description, objet.getDescription());
+        assertEquals(categorie, objet.getCategorie());
+        assertEquals(dateCreation, objet.getDateCreation());
     }
 
-    /**
-     * Tests the getId method of the Objet class.
-     * Verifies that the ID is returned correctly.
-     */
     @Test
-    void testObjetId() {
-        assertEquals(1L, objet.getId());
-    }
+    void defaultConstructor_SetsFieldsToNull() {
+        Objet objet = new Objet();
 
-    /**
-     * Tests the getNom method of the Objet class.
-     * Verifies that the name is returned correctly.
-     */
-    @Test
-    void testObjetNom() {
-        assertEquals("Test Objet", objet.getNom());
-    }
-
-    /**
-     * Tests the getCategorie method of the Objet class.
-     * Verifies that the category is returned correctly.
-     */
-    @Test
-    void testObjetCategorie() {
-        assertEquals(CategorieObjet.INFORMATIQUE, objet.getCategorie());
-    }
-
-    /**
-     * Tests the getDescription method of the Objet class.
-     * Verifies that the description is returned correctly.
-     */
-    @Test
-    void testObjetDescription() {
-        assertEquals("Description de test", objet.getDescription());
-    }
-
-    /**
-     * Tests the getDateCreation method of the Objet class.
-     * Verifies that the creation date is returned correctly.
-     */
-    @Test
-    void testObjetDateCreation() {
-        assertNotNull(objet.getDateCreation());
-    }
-
-    /**
-     * Tests the getUtilisateur method of the Objet class.
-     * Verifies that the user is returned correctly.
-     */
-    @Test
-    void testObjetUtilisateur() {
         assertNull(objet.getUtilisateur());
+        assertNull(objet.getNom());
+        assertNull(objet.getDescription());
+        assertNull(objet.getCategorie());
+        assertNull(objet.getDateCreation());
     }
 
-    /**
-     * Tests the getNom method of the second Objet instance.
-     * Verifies that the name is returned correctly.
-     */
     @Test
-    void testObjetNom2() {
-        assertEquals("Test Objet 2", objet2.getNom());
+    void setUtilisateur_UpdatesUtilisateur() {
+        Objet objet = new Objet();
+        Utilisateur utilisateur = new Utilisateur();
+        objet.setUtilisateur(utilisateur);
+
+        assertEquals(utilisateur, objet.getUtilisateur());
     }
 
-    /**
-     * Tests the getCategorie method of the second Objet instance.
-     * Verifies that the category is returned correctly.
-     */
     @Test
-    void testObjetCategorie2() {
-        assertEquals(CategorieObjet.INFORMATIQUE, objet2.getCategorie());
+    void setNom_UpdatesNom() {
+        Objet objet = new Objet();
+        String nom = "Smartphone";
+        objet.setNom(nom);
+
+        assertEquals(nom, objet.getNom());
     }
 
-    /**
-     * Tests the getDescription method of the second Objet instance.
-     * Verifies that the description is returned correctly.
-     */
     @Test
-    void testObjetDescription2() {
-        assertEquals("Description de test 2", objet2.getDescription());
+    void setDescription_UpdatesDescription() {
+        Objet objet = new Objet();
+        String description = "A brand new smartphone";
+        objet.setDescription(description);
+
+        assertEquals(description, objet.getDescription());
     }
 
-    /**
-     * Tests the getDateCreation method of the second Objet instance.
-     * Verifies that the creation date is returned correctly.
-     */
     @Test
-    void testObjetDateCreation2() {
-        assertNotNull(objet2.getDateCreation());
+    void setCategorie_UpdatesCategorie() {
+        Objet objet = new Objet();
+        CategorieObjet categorie = CategorieObjet.ELECTROMENAGER;
+        objet.setCategorie(categorie);
+
+        assertEquals(categorie, objet.getCategorie());
     }
 
-    /**
-     * Tests the getUtilisateur method of the second Objet instance.
-     * Verifies that the user is returned correctly.
-     */
     @Test
-    void testObjetUtilisateur2() {
-        assertNull(objet2.getUtilisateur());
+    void setDateCreation_UpdatesDateCreation() {
+        Objet objet = new Objet();
+        LocalDateTime dateCreation = LocalDateTime.now();
+        objet.setDateCreation(dateCreation);
+
+        assertEquals(dateCreation, objet.getDateCreation());
     }
 }

--- a/Backend/src/test/java/fr/knap/testunitaire_esiee/model/ObjetTest.java
+++ b/Backend/src/test/java/fr/knap/testunitaire_esiee/model/ObjetTest.java
@@ -4,11 +4,18 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import java.time.LocalDateTime;
+
 import static org.junit.jupiter.api.Assertions.*;
 
+/**
+ * Unit tests for the Objet class.
+ */
 @SpringBootTest
 class ObjetTest {
 
+    /**
+     * Tests the constructor with parameters to ensure it sets all fields correctly.
+     */
     @Test
     void constructorWithParameters_SetsAllFields() {
         Utilisateur utilisateur = new Utilisateur();
@@ -26,6 +33,9 @@ class ObjetTest {
         assertEquals(dateCreation, objet.getDateCreation());
     }
 
+    /**
+     * Tests the default constructor to ensure it sets all fields to null.
+     */
     @Test
     void defaultConstructor_SetsFieldsToNull() {
         Objet objet = new Objet();
@@ -37,6 +47,9 @@ class ObjetTest {
         assertNull(objet.getDateCreation());
     }
 
+    /**
+     * Tests the setUtilisateur method to ensure it updates the utilisateur field.
+     */
     @Test
     void setUtilisateur_UpdatesUtilisateur() {
         Objet objet = new Objet();
@@ -46,6 +59,9 @@ class ObjetTest {
         assertEquals(utilisateur, objet.getUtilisateur());
     }
 
+    /**
+     * Tests the setNom method to ensure it updates the nom field.
+     */
     @Test
     void setNom_UpdatesNom() {
         Objet objet = new Objet();
@@ -55,6 +71,9 @@ class ObjetTest {
         assertEquals(nom, objet.getNom());
     }
 
+    /**
+     * Tests the setDescription method to ensure it updates the description field.
+     */
     @Test
     void setDescription_UpdatesDescription() {
         Objet objet = new Objet();
@@ -64,6 +83,9 @@ class ObjetTest {
         assertEquals(description, objet.getDescription());
     }
 
+    /**
+     * Tests the setCategorie method to ensure it updates the categorie field.
+     */
     @Test
     void setCategorie_UpdatesCategorie() {
         Objet objet = new Objet();
@@ -73,6 +95,9 @@ class ObjetTest {
         assertEquals(categorie, objet.getCategorie());
     }
 
+    /**
+     * Tests the setDateCreation method to ensure it updates the dateCreation field.
+     */
     @Test
     void setDateCreation_UpdatesDateCreation() {
         Objet objet = new Objet();

--- a/Backend/src/test/java/fr/knap/testunitaire_esiee/model/TokenTest.java
+++ b/Backend/src/test/java/fr/knap/testunitaire_esiee/model/TokenTest.java
@@ -1,72 +1,73 @@
 package fr.knap.testunitaire_esiee.model;
 
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-/**
- * Unit tests for the Token class.
- */
+import java.util.Date;
+
 @SpringBootTest
 class TokenTest {
 
-    private static Token token;
-
-    /**
-     * Sets up the test environment before all tests.
-     * Initializes the Token instance with test data.
-     */
-    @BeforeAll
-    static void setUp() {
-        token = new Token("test@mail.com", "password");
-    }
-
-    /**
-     * Tests the token creation.
-     * Verifies that the token is not null after creation.
-     */
     @Test
-    void testTokenCreation() {
+    void constructorWithParameters_SetsTokenAndExpirationDate() {
+        String mail = "user@example.com";
+        String mdp = "password123";
+        Token token = new Token(mail, mdp);
+
         assertNotNull(token.getToken());
+        assertNotNull(token.getExpirationDate());
+        assertTrue(token.getExpirationDate().after(new Date()));
     }
 
-    /**
-     * Tests the token validation.
-     * Verifies that a valid token is correctly validated.
-     */
     @Test
-    void testTokenValidation() {
+    void defaultConstructor_SetsFieldsToNull() {
+        Token token = new Token();
+
+        assertNull(token.getToken());
+        assertNull(token.getExpirationDate());
+    }
+
+    @Test
+    void validateToken_ValidToken_ReturnsTrue() {
+        String mail = "user@example.com";
+        String mdp = "password123";
+        Token token = new Token(mail, mdp);
+
         assertTrue(Token.validateToken(token.getToken()));
     }
 
-    /**
-     * Tests the token invalidation.
-     * Verifies that an invalid token is correctly invalidated.
-     */
     @Test
-    void testTokenInvalidation() {
+    void validateToken_InvalidToken_ReturnsFalse() {
         assertFalse(Token.validateToken("invalidToken"));
     }
 
-    /**
-     * Tests the token subject retrieval.
-     * Verifies that the subject of the token is returned correctly.
-     */
     @Test
-    void testTokenSubject() {
-        assertEquals("test@mail.compassword", Token.getSubject(token.getToken()));
+    void getSubject_ValidToken_ReturnsSubject() {
+        String mail = "user@example.com";
+        String mdp = "password123";
+        Token token = new Token(mail, mdp);
+
+        assertEquals(mail + "#" + mdp, Token.getSubject(token.getToken()));
     }
 
-    // TODO: Fix the test
-    // /**
-    //  * Tests the token disconnection.
-    //  * Verifies that the token is disconnected correctly.
-    //  */
-    // @Test
-    // void testTokenDisconnect() {
-    //     token.disconnect();
-    //     assertNull(token.getToken());
-    // }
+    @Test
+    void getEmail_ValidToken_ReturnsEmail() {
+        String mail = "user@example.com";
+        String mdp = "password123";
+        Token token = new Token(mail, mdp);
+
+        assertEquals(mail, Token.getEmail(token.getToken()));
+    }
+
+    @Test
+    void disconnect_SetsExpirationDateToCurrentTime() {
+        String mail = "user@example.com";
+        String mdp = "password123";
+        Token token = new Token(mail, mdp);
+        token.disconnect();
+
+        assertTrue(token.getExpirationDate().before(new Date()) || token.getExpirationDate().equals(new Date()));
+    }
 }

--- a/Backend/src/test/java/fr/knap/testunitaire_esiee/model/TokenTest.java
+++ b/Backend/src/test/java/fr/knap/testunitaire_esiee/model/TokenTest.java
@@ -7,9 +7,15 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.Date;
 
+/**
+ * Unit tests for the Token class.
+ */
 @SpringBootTest
 class TokenTest {
 
+    /**
+     * Tests the constructor with parameters to ensure it sets the token and expiration date fields correctly.
+     */
     @Test
     void constructorWithParameters_SetsTokenAndExpirationDate() {
         String mail = "user@example.com";
@@ -21,6 +27,9 @@ class TokenTest {
         assertTrue(token.getExpirationDate().after(new Date()));
     }
 
+    /**
+     * Tests the default constructor to ensure it sets the token and expiration date fields to null.
+     */
     @Test
     void defaultConstructor_SetsFieldsToNull() {
         Token token = new Token();
@@ -29,6 +38,9 @@ class TokenTest {
         assertNull(token.getExpirationDate());
     }
 
+    /**
+     * Tests the validateToken method with a valid token to ensure it returns true.
+     */
     @Test
     void validateToken_ValidToken_ReturnsTrue() {
         String mail = "user@example.com";
@@ -38,11 +50,17 @@ class TokenTest {
         assertTrue(Token.validateToken(token.getToken()));
     }
 
+    /**
+     * Tests the validateToken method with an invalid token to ensure it returns false.
+     */
     @Test
     void validateToken_InvalidToken_ReturnsFalse() {
         assertFalse(Token.validateToken("invalidToken"));
     }
 
+    /**
+     * Tests the getSubject method with a valid token to ensure it returns the correct subject.
+     */
     @Test
     void getSubject_ValidToken_ReturnsSubject() {
         String mail = "user@example.com";
@@ -52,6 +70,9 @@ class TokenTest {
         assertEquals(mail + "#" + mdp, Token.getSubject(token.getToken()));
     }
 
+    /**
+     * Tests the getEmail method with a valid token to ensure it returns the correct email.
+     */
     @Test
     void getEmail_ValidToken_ReturnsEmail() {
         String mail = "user@example.com";
@@ -61,6 +82,9 @@ class TokenTest {
         assertEquals(mail, Token.getEmail(token.getToken()));
     }
 
+    /**
+     * Tests the disconnect method to ensure it sets the expiration date to the current time.
+     */
     @Test
     void disconnect_SetsExpirationDateToCurrentTime() {
         String mail = "user@example.com";

--- a/Backend/src/test/java/fr/knap/testunitaire_esiee/model/UtilisateurTest.java
+++ b/Backend/src/test/java/fr/knap/testunitaire_esiee/model/UtilisateurTest.java
@@ -1,117 +1,118 @@
 package fr.knap.testunitaire_esiee.model;
 
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import static org.junit.jupiter.api.Assertions.*;
-
 import java.util.ArrayList;
+import java.util.List;
 
-/**
- * Unit tests for the Utilisateur class.
- */
 @SpringBootTest
 class UtilisateurTest {
 
-    private static Utilisateur utilisateur;
-    private static Utilisateur utilisateur2;
-    private static Utilisateur utilisateur3;
-
-    /**
-     * Sets up the test environment before all tests.
-     * Initializes the Utilisateur instances with test data.
-     */
-    @BeforeAll
-    static void setUp() {
-        utilisateur = new Utilisateur();
-        utilisateur.setPseudo("testPseudo");
-        utilisateur.setMdp("testMdp");
-        utilisateur.setMail("test@mail.com");
-        utilisateur.setNom("TestNom");
-        utilisateur.setPrenom("TestPrenom");
-        utilisateur.setObjets(new ArrayList<>());
-
-        utilisateur2 = new Utilisateur(
-                "testPseudo2",
-                "testMdp2",
-                "test2@mail.com",
-                "TestNom2",
-                "TestPrenom2"
-        );
-
-        utilisateur3 = new Utilisateur(
-                "testPseudo3",
-                "testMdp3",
-                "test3@mail.com",
-                "TestNom3",
-                "TestPrenom3",
-                new ArrayList<>()
-        );
-    }
-
-    /**
-     * Tests the getPseudo method of the Utilisateur class.
-     * Verifies that the pseudonyms are returned correctly.
-     */
     @Test
-    void testUtilisateurPseudo() {
-        assertEquals("testPseudo", utilisateur.getPseudo());
-        assertEquals("testPseudo2", utilisateur2.getPseudo());
-        assertEquals("testPseudo3", utilisateur3.getPseudo());
-    }
+    void constructorWithParameters_SetsAllFields() {
+        String pseudo = "user123";
+        String mdp = "password123";
+        String mail = "user@example.com";
+        String nom = "Doe";
+        String prenom = "John";
 
-    /**
-     * Tests the getMdp method of the Utilisateur class.
-     * Verifies that the passwords are returned correctly.
-     */
-    @Test
-    void testUtilisateurMdp() {
-        assertEquals("testMdp", utilisateur.getMdp());
-        assertEquals("testMdp2", utilisateur2.getMdp());
-        assertEquals("testMdp3", utilisateur3.getMdp());
-    }
+        Utilisateur utilisateur = new Utilisateur(pseudo, mdp, mail, nom, prenom);
 
-    /**
-     * Tests the getMail method of the Utilisateur class.
-     * Verifies that the email addresses are returned correctly.
-     */
-    @Test
-    void testUtilisateurMail() {
-        assertEquals("test@mail.com", utilisateur.getMail());
-        assertEquals("test2@mail.com", utilisateur2.getMail());
-        assertEquals("test3@mail.com", utilisateur3.getMail());
-    }
-
-    /**
-     * Tests the getNom method of the Utilisateur class.
-     * Verifies that the last names are returned correctly.
-     */
-    @Test
-    void testUtilisateurNom() {
-        assertEquals("TestNom", utilisateur.getNom());
-        assertEquals("TestNom2", utilisateur2.getNom());
-        assertEquals("TestNom3", utilisateur3.getNom());
-    }
-
-    /**
-     * Tests the getPrenom method of the Utilisateur class.
-     * Verifies that the first names are returned correctly.
-     */
-    @Test
-    void testUtilisateurPrenom() {
-        assertEquals("TestPrenom", utilisateur.getPrenom());
-        assertEquals("TestPrenom2", utilisateur2.getPrenom());
-        assertEquals("TestPrenom3", utilisateur3.getPrenom());
-    }
-
-    /**
-     * Tests the getObjets method of the Utilisateur class.
-     * Verifies that the objects list is not null.
-     */
-    @Test
-    void testUtilisateurObjets() {
+        assertEquals(pseudo, utilisateur.getPseudo());
+        assertEquals(mdp, utilisateur.getMdp());
+        assertEquals(mail, utilisateur.getMail());
+        assertEquals(nom, utilisateur.getNom());
+        assertEquals(prenom, utilisateur.getPrenom());
         assertNotNull(utilisateur.getObjets());
-        assertNotNull(utilisateur3.getObjets());
+        assertTrue(utilisateur.getObjets().isEmpty());
+    }
+
+    @Test
+    void constructorWithParametersAndObjects_SetsAllFields() {
+        String pseudo = "user123";
+        String mdp = "password123";
+        String mail = "user@example.com";
+        String nom = "Doe";
+        String prenom = "John";
+        List<Objet> objets = new ArrayList<>();
+        objets.add(new Objet());
+
+        Utilisateur utilisateur = new Utilisateur(pseudo, mdp, mail, nom, prenom, objets);
+
+        assertEquals(pseudo, utilisateur.getPseudo());
+        assertEquals(mdp, utilisateur.getMdp());
+        assertEquals(mail, utilisateur.getMail());
+        assertEquals(nom, utilisateur.getNom());
+        assertEquals(prenom, utilisateur.getPrenom());
+        assertEquals(objets, utilisateur.getObjets());
+    }
+
+    @Test
+    void defaultConstructor_SetsFieldsToNull() {
+        Utilisateur utilisateur = new Utilisateur();
+
+        assertNull(utilisateur.getPseudo());
+        assertNull(utilisateur.getMdp());
+        assertNull(utilisateur.getMail());
+        assertNull(utilisateur.getNom());
+        assertNull(utilisateur.getPrenom());
+        assertNull(utilisateur.getObjets());
+    }
+
+    @Test
+    void setPseudo_UpdatesPseudo() {
+        Utilisateur utilisateur = new Utilisateur();
+        String pseudo = "newUser123";
+        utilisateur.setPseudo(pseudo);
+
+        assertEquals(pseudo, utilisateur.getPseudo());
+    }
+
+    @Test
+    void setMdp_UpdatesMdp() {
+        Utilisateur utilisateur = new Utilisateur();
+        String mdp = "newPassword123";
+        utilisateur.setMdp(mdp);
+
+        assertEquals(mdp, utilisateur.getMdp());
+    }
+
+    @Test
+    void setMail_UpdatesMail() {
+        Utilisateur utilisateur = new Utilisateur();
+        String mail = "newuser@example.com";
+        utilisateur.setMail(mail);
+
+        assertEquals(mail, utilisateur.getMail());
+    }
+
+    @Test
+    void setNom_UpdatesNom() {
+        Utilisateur utilisateur = new Utilisateur();
+        String nom = "Smith";
+        utilisateur.setNom(nom);
+
+        assertEquals(nom, utilisateur.getNom());
+    }
+
+    @Test
+    void setPrenom_UpdatesPrenom() {
+        Utilisateur utilisateur = new Utilisateur();
+        String prenom = "Jane";
+        utilisateur.setPrenom(prenom);
+
+        assertEquals(prenom, utilisateur.getPrenom());
+    }
+
+    @Test
+    void setObjets_UpdatesObjets() {
+        Utilisateur utilisateur = new Utilisateur();
+        List<Objet> objets = new ArrayList<>();
+        objets.add(new Objet());
+        utilisateur.setObjets(objets);
+
+        assertEquals(objets, utilisateur.getObjets());
     }
 }

--- a/Backend/src/test/java/fr/knap/testunitaire_esiee/model/UtilisateurTest.java
+++ b/Backend/src/test/java/fr/knap/testunitaire_esiee/model/UtilisateurTest.java
@@ -4,12 +4,19 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import static org.junit.jupiter.api.Assertions.*;
+
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * Unit tests for the Utilisateur class.
+ */
 @SpringBootTest
 class UtilisateurTest {
 
+    /**
+     * Tests the constructor with parameters to ensure it sets all fields correctly.
+     */
     @Test
     void constructorWithParameters_SetsAllFields() {
         String pseudo = "user123";
@@ -29,6 +36,9 @@ class UtilisateurTest {
         assertTrue(utilisateur.getObjets().isEmpty());
     }
 
+    /**
+     * Tests the constructor with parameters and objects to ensure it sets all fields correctly.
+     */
     @Test
     void constructorWithParametersAndObjects_SetsAllFields() {
         String pseudo = "user123";
@@ -49,6 +59,9 @@ class UtilisateurTest {
         assertEquals(objets, utilisateur.getObjets());
     }
 
+    /**
+     * Tests the default constructor to ensure it sets all fields to null.
+     */
     @Test
     void defaultConstructor_SetsFieldsToNull() {
         Utilisateur utilisateur = new Utilisateur();
@@ -61,6 +74,9 @@ class UtilisateurTest {
         assertNull(utilisateur.getObjets());
     }
 
+    /**
+     * Tests the setPseudo method to ensure it updates the pseudo field.
+     */
     @Test
     void setPseudo_UpdatesPseudo() {
         Utilisateur utilisateur = new Utilisateur();
@@ -70,6 +86,9 @@ class UtilisateurTest {
         assertEquals(pseudo, utilisateur.getPseudo());
     }
 
+    /**
+     * Tests the setMdp method to ensure it updates the mdp field.
+     */
     @Test
     void setMdp_UpdatesMdp() {
         Utilisateur utilisateur = new Utilisateur();
@@ -79,6 +98,9 @@ class UtilisateurTest {
         assertEquals(mdp, utilisateur.getMdp());
     }
 
+    /**
+     * Tests the setMail method to ensure it updates the mail field.
+     */
     @Test
     void setMail_UpdatesMail() {
         Utilisateur utilisateur = new Utilisateur();
@@ -88,6 +110,9 @@ class UtilisateurTest {
         assertEquals(mail, utilisateur.getMail());
     }
 
+    /**
+     * Tests the setNom method to ensure it updates the nom field.
+     */
     @Test
     void setNom_UpdatesNom() {
         Utilisateur utilisateur = new Utilisateur();
@@ -97,6 +122,9 @@ class UtilisateurTest {
         assertEquals(nom, utilisateur.getNom());
     }
 
+    /**
+     * Tests the setPrenom method to ensure it updates the prenom field.
+     */
     @Test
     void setPrenom_UpdatesPrenom() {
         Utilisateur utilisateur = new Utilisateur();
@@ -106,6 +134,9 @@ class UtilisateurTest {
         assertEquals(prenom, utilisateur.getPrenom());
     }
 
+    /**
+     * Tests the setObjets method to ensure it updates the objets field.
+     */
     @Test
     void setObjets_UpdatesObjets() {
         Utilisateur utilisateur = new Utilisateur();

--- a/Backend/src/test/java/fr/knap/testunitaire_esiee/services/EchangeServiceTest.java
+++ b/Backend/src/test/java/fr/knap/testunitaire_esiee/services/EchangeServiceTest.java
@@ -1,54 +1,108 @@
 package fr.knap.testunitaire_esiee.services;
 
-    import fr.knap.testunitaire_esiee.model.Echange;
-    import fr.knap.testunitaire_esiee.repository.EchangeRepository;
-    import org.junit.jupiter.api.BeforeEach;
-    import org.junit.jupiter.api.Test;
-    import org.mockito.InjectMocks;
-    import org.mockito.Mock;
-    import org.mockito.MockitoAnnotations;
+import fr.knap.testunitaire_esiee.model.Echange;
+import fr.knap.testunitaire_esiee.repository.EchangeRepository;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.boot.test.context.SpringBootTest;
 
-    import static org.junit.jupiter.api.Assertions.*;
-    import static org.mockito.Mockito.*;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
 
-    /**
-     * Unit tests for the EchangeService class.
-     */
-    class EchangeServiceTest {
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
-        @Mock
-        private EchangeRepository echangeRepository;
+@SpringBootTest
+class EchangeServiceTest {
 
-        @InjectMocks
-        private EchangeService echangeService;
+    @Mock
+    private EchangeRepository echangeRepository;
 
-        /**
-         * Sets up the test environment before each test.
-         * Initializes the mocks and injects them into the EchangeService instance.
-         */
-        @BeforeEach
-        void setUp() {
-            MockitoAnnotations.openMocks(this);
-        }
+    @InjectMocks
+    private EchangeService echangeService;
 
-        /**
-         * Tests the creerEchange method of the EchangeService class.
-         * Verifies that an exchange is created and saved correctly.
-         */
-        @Test
-        void testCreerEchange() {
-            Echange echange = new Echange();
-            when(echangeRepository.save(echange)).thenReturn(echange);
-            assertEquals(echange, echangeService.creerEchange(echange));
-        }
-
-        /**
-         * Tests the obtenirTousLesEchanges method of the EchangeService class.
-         * Verifies that all exchanges are retrieved correctly.
-         */
-        @Test
-        void testObtenirTousLesEchanges() {
-            echangeService.obtenirTousLesEchanges();
-            verify(echangeRepository, times(1)).findAll();
-        }
+    public EchangeServiceTest() {
+        MockitoAnnotations.openMocks(this);
     }
+
+    @Test
+    void creerEchange_SavesAndReturnsEchange() {
+        Echange echange = new Echange();
+        when(echangeRepository.save(echange)).thenReturn(echange);
+
+        Echange result = echangeService.creerEchange(echange);
+
+        assertEquals(echange, result);
+        verify(echangeRepository, times(1)).save(echange);
+    }
+
+    @Test
+    void obtenirTousLesEchanges_ReturnsAllEchanges() {
+        List<Echange> echanges = Arrays.asList(new Echange(), new Echange());
+        when(echangeRepository.findAll()).thenReturn(echanges);
+
+        List<Echange> result = echangeService.obtenirTousLesEchanges();
+
+        assertEquals(echanges, result);
+        verify(echangeRepository, times(1)).findAll();
+    }
+
+    @Test
+    void obtenirEchangeParId_ReturnsEchangeIfExists() {
+        Long id = 1L;
+        Echange echange = new Echange();
+        when(echangeRepository.findById(id)).thenReturn(Optional.of(echange));
+
+        Echange result = echangeService.obtenirEchangeParId(id);
+
+        assertEquals(echange, result);
+        verify(echangeRepository, times(1)).findById(id);
+    }
+
+    @Test
+    void obtenirEchangeParId_ReturnsNullIfNotExists() {
+        Long id = 1L;
+        when(echangeRepository.findById(id)).thenReturn(Optional.empty());
+
+        Echange result = echangeService.obtenirEchangeParId(id);
+
+        assertNull(result);
+        verify(echangeRepository, times(1)).findById(id);
+    }
+
+    @Test
+    void mettreAJourEchange_SavesAndReturnsUpdatedEchange() {
+        Echange echange = new Echange();
+        when(echangeRepository.save(echange)).thenReturn(echange);
+
+        Echange result = echangeService.mettreAJourEchange(echange);
+
+        assertEquals(echange, result);
+        verify(echangeRepository, times(1)).save(echange);
+    }
+
+    @Test
+    void echangeExist_ReturnsTrueIfExists() {
+        Long id = 1L;
+        when(echangeRepository.existsById(id)).thenReturn(true);
+
+        boolean result = echangeService.echangeExist(id);
+
+        assertTrue(result);
+        verify(echangeRepository, times(1)).existsById(id);
+    }
+
+    @Test
+    void echangeExist_ReturnsFalseIfNotExists() {
+        Long id = 1L;
+        when(echangeRepository.existsById(id)).thenReturn(false);
+
+        boolean result = echangeService.echangeExist(id);
+
+        assertFalse(result);
+        verify(echangeRepository, times(1)).existsById(id);
+    }
+}

--- a/Backend/src/test/java/fr/knap/testunitaire_esiee/services/EchangeServiceTest.java
+++ b/Backend/src/test/java/fr/knap/testunitaire_esiee/services/EchangeServiceTest.java
@@ -15,6 +15,9 @@ import java.util.Optional;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+/**
+ * Unit tests for the EchangeService class.
+ */
 @SpringBootTest
 class EchangeServiceTest {
 
@@ -24,10 +27,16 @@ class EchangeServiceTest {
     @InjectMocks
     private EchangeService echangeService;
 
+    /**
+     * Initializes mocks for the test class.
+     */
     public EchangeServiceTest() {
         MockitoAnnotations.openMocks(this);
     }
 
+    /**
+     * Tests the creerEchange method to ensure it saves and returns the Echange object.
+     */
     @Test
     void creerEchange_SavesAndReturnsEchange() {
         Echange echange = new Echange();
@@ -39,6 +48,9 @@ class EchangeServiceTest {
         verify(echangeRepository, times(1)).save(echange);
     }
 
+    /**
+     * Tests the obtenirTousLesEchanges method to ensure it returns all Echange objects.
+     */
     @Test
     void obtenirTousLesEchanges_ReturnsAllEchanges() {
         List<Echange> echanges = Arrays.asList(new Echange(), new Echange());
@@ -50,6 +62,9 @@ class EchangeServiceTest {
         verify(echangeRepository, times(1)).findAll();
     }
 
+    /**
+     * Tests the obtenirEchangeParId method to ensure it returns the Echange object if it exists.
+     */
     @Test
     void obtenirEchangeParId_ReturnsEchangeIfExists() {
         Long id = 1L;
@@ -62,6 +77,9 @@ class EchangeServiceTest {
         verify(echangeRepository, times(1)).findById(id);
     }
 
+    /**
+     * Tests the obtenirEchangeParId method to ensure it returns null if the Echange object does not exist.
+     */
     @Test
     void obtenirEchangeParId_ReturnsNullIfNotExists() {
         Long id = 1L;
@@ -73,6 +91,9 @@ class EchangeServiceTest {
         verify(echangeRepository, times(1)).findById(id);
     }
 
+    /**
+     * Tests the mettreAJourEchange method to ensure it saves and returns the updated Echange object.
+     */
     @Test
     void mettreAJourEchange_SavesAndReturnsUpdatedEchange() {
         Echange echange = new Echange();
@@ -84,6 +105,9 @@ class EchangeServiceTest {
         verify(echangeRepository, times(1)).save(echange);
     }
 
+    /**
+     * Tests the echangeExist method to ensure it returns true if the Echange object exists.
+     */
     @Test
     void echangeExist_ReturnsTrueIfExists() {
         Long id = 1L;
@@ -95,6 +119,9 @@ class EchangeServiceTest {
         verify(echangeRepository, times(1)).existsById(id);
     }
 
+    /**
+     * Tests the echangeExist method to ensure it returns false if the Echange object does not exist.
+     */
     @Test
     void echangeExist_ReturnsFalseIfNotExists() {
         Long id = 1L;

--- a/Backend/src/test/java/fr/knap/testunitaire_esiee/services/ObjetServiceTest.java
+++ b/Backend/src/test/java/fr/knap/testunitaire_esiee/services/ObjetServiceTest.java
@@ -20,6 +20,9 @@ import java.util.Optional;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+/**
+ * Unit tests for the ObjetService class.
+ */
 @SpringBootTest
 class ObjetServiceTest {
 
@@ -32,10 +35,16 @@ class ObjetServiceTest {
     @InjectMocks
     private ObjetService objetService;
 
+    /**
+     * Initializes mocks for the test class.
+     */
     public ObjetServiceTest() {
         MockitoAnnotations.openMocks(this);
     }
 
+    /**
+     * Tests the creerObjet method to ensure it saves and returns the Objet object.
+     */
     @Test
     void creerObjet_SavesAndReturnsObjet() {
         Objet objet = new Objet();
@@ -47,6 +56,9 @@ class ObjetServiceTest {
         verify(objetRepository, times(1)).save(objet);
     }
 
+    /**
+     * Tests the obtenirTousLesObjets method to ensure it returns all Objet objects.
+     */
     @Test
     void obtenirTousLesObjets_ReturnsAllObjets() {
         Utilisateur utilisateur = new Utilisateur();
@@ -66,6 +78,9 @@ class ObjetServiceTest {
         verify(objetRepository, times(1)).findAll();
     }
 
+    /**
+     * Tests the obtenirObjetParId method to ensure it returns the Objet object if it exists.
+     */
     @Test
     void obtenirObjetParId_ReturnsObjetIfExists() {
         Long id = 1L;
@@ -78,6 +93,9 @@ class ObjetServiceTest {
         verify(objetRepository, times(1)).findById(id);
     }
 
+    /**
+     * Tests the obtenirObjetParId method to ensure it returns null if the Objet object does not exist.
+     */
     @Test
     void obtenirObjetParId_ReturnsNullIfNotExists() {
         Long id = 1L;
@@ -89,6 +107,9 @@ class ObjetServiceTest {
         verify(objetRepository, times(1)).findById(id);
     }
 
+    /**
+     * Tests the mettreAJourObjet method to ensure it saves and returns the updated Objet object.
+     */
     @Test
     void mettreAJourObjet_SavesAndReturnsUpdatedObjet() {
         Long id = 1L;
@@ -102,6 +123,9 @@ class ObjetServiceTest {
         verify(objetRepository, times(1)).save(objet);
     }
 
+    /**
+     * Tests the mettreAJourObjet method to ensure it returns null if the Objet object does not exist.
+     */
     @Test
     void mettreAJourObjet_ReturnsNullIfNotExists() {
         Long id = 1L;
@@ -114,6 +138,9 @@ class ObjetServiceTest {
         verify(objetRepository, times(0)).save(objet);
     }
 
+    /**
+     * Tests the supprimerObjet method to ensure it deletes the Objet object.
+     */
     @Test
     void supprimerObjet_DeletesObjet() {
         Long id = 1L;
@@ -123,6 +150,9 @@ class ObjetServiceTest {
         verify(objetRepository, times(1)).deleteById(id);
     }
 
+    /**
+     * Tests the obtenirObjetsParUtilisateur method to ensure it returns the Objet objects if the user exists.
+     */
     @Test
     void obtenirObjetsParUtilisateur_ReturnsObjetsIfUserExists() {
         Long idUtilisateur = 1L;
@@ -130,8 +160,8 @@ class ObjetServiceTest {
         utilisateur.setPseudo("user123");
         utilisateur.setId(idUtilisateur);
 
-        Objet objet1 = new Objet(utilisateur,"Laptop", "A high-end gaming laptop", CategorieObjet.INFORMATIQUE, LocalDateTime.now());
-        Objet objet2 = new Objet(utilisateur,"Smartphone", "A brand new smartphone", CategorieObjet.ELECTROMENAGER, LocalDateTime.now());
+        Objet objet1 = new Objet(utilisateur, "Laptop", "A high-end gaming laptop", CategorieObjet.INFORMATIQUE, LocalDateTime.now());
+        Objet objet2 = new Objet(utilisateur, "Smartphone", "A brand new smartphone", CategorieObjet.ELECTROMENAGER, LocalDateTime.now());
 
         when(utilisateurRepository.findById(idUtilisateur)).thenReturn(Optional.of(utilisateur));
         when(objetRepository.findByUtilisateurId(idUtilisateur)).thenReturn(Arrays.asList(objet1, objet2));
@@ -145,6 +175,9 @@ class ObjetServiceTest {
         verify(objetRepository, times(1)).findByUtilisateurId(idUtilisateur);
     }
 
+    /**
+     * Tests the obtenirObjetsParUtilisateur method to ensure it returns null if the user does not exist.
+     */
     @Test
     void obtenirObjetsParUtilisateur_ReturnsNullIfUserNotExists() {
         Long idUtilisateur = 1L;

--- a/Backend/src/test/java/fr/knap/testunitaire_esiee/services/ObjetServiceTest.java
+++ b/Backend/src/test/java/fr/knap/testunitaire_esiee/services/ObjetServiceTest.java
@@ -1,99 +1,159 @@
 package fr.knap.testunitaire_esiee.services;
 
+import fr.knap.testunitaire_esiee.dto.ObjetDTO;
+import fr.knap.testunitaire_esiee.model.CategorieObjet;
 import fr.knap.testunitaire_esiee.model.Objet;
+import fr.knap.testunitaire_esiee.model.Utilisateur;
 import fr.knap.testunitaire_esiee.repository.ObjetRepository;
-import org.junit.jupiter.api.BeforeEach;
+import fr.knap.testunitaire_esiee.repository.UtilisateurRepository;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.springframework.boot.test.context.SpringBootTest;
 
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
-/**
- * Unit tests for the ObjetService class.
- */
+@SpringBootTest
 class ObjetServiceTest {
 
     @Mock
     private ObjetRepository objetRepository;
 
+    @Mock
+    private UtilisateurRepository utilisateurRepository;
+
     @InjectMocks
     private ObjetService objetService;
 
-    /**
-     * Sets up the test environment before each test.
-     * Initializes the mocks and injects them into the ObjetService instance.
-     */
-    @BeforeEach
-    void setUp() {
+    public ObjetServiceTest() {
         MockitoAnnotations.openMocks(this);
     }
 
-    /**
-     * Tests the creerObjet method of the ObjetService class.
-     * Verifies that an object is created and saved correctly.
-     */
     @Test
-    void testCreerObjet() {
+    void creerObjet_SavesAndReturnsObjet() {
         Objet objet = new Objet();
         when(objetRepository.save(objet)).thenReturn(objet);
-        assertEquals(objet, objetService.creerObjet(objet));
+
+        Objet result = objetService.creerObjet(objet);
+
+        assertEquals(objet, result);
+        verify(objetRepository, times(1)).save(objet);
     }
 
-    /**
-     * Tests the obtenirTousLesObjets method of the ObjetService class.
-     * Verifies that all objects are retrieved correctly.
-     */
     @Test
-    void testObtenirTousLesObjets() {
-        objetService.obtenirTousLesObjets();
+    void obtenirTousLesObjets_ReturnsAllObjets() {
+        Utilisateur utilisateur = new Utilisateur();
+        utilisateur.setPseudo("user123");
+        utilisateur.setId(1L);
+
+        Objet objet1 = new Objet(utilisateur, "Laptop", "A high-end gaming laptop", CategorieObjet.INFORMATIQUE, LocalDateTime.now());
+        Objet objet2 = new Objet(utilisateur, "Smartphone", "A brand new smartphone", CategorieObjet.ELECTROMENAGER, LocalDateTime.now());
+
+        when(objetRepository.findAll()).thenReturn(Arrays.asList(objet1, objet2));
+
+        List<ObjetDTO> result = objetService.obtenirTousLesObjets();
+
+        assertEquals(2, result.size());
+        assertEquals("Laptop", result.get(0).getNom());
+        assertEquals("Smartphone", result.get(1).getNom());
         verify(objetRepository, times(1)).findAll();
     }
 
-    /**
-     * Tests the obtenirObjetParId method of the ObjetService class.
-     * Verifies that an object is retrieved correctly by its ID.
-     */
     @Test
-    void testObtenirObjetParId() {
+    void obtenirObjetParId_ReturnsObjetIfExists() {
+        Long id = 1L;
         Objet objet = new Objet();
-        when(objetRepository.findById(1L)).thenReturn(Optional.of(objet));
-        assertEquals(objet, objetService.obtenirObjetParId(1L));
+        when(objetRepository.findById(id)).thenReturn(Optional.of(objet));
+
+        Objet result = objetService.obtenirObjetParId(id);
+
+        assertEquals(objet, result);
+        verify(objetRepository, times(1)).findById(id);
     }
 
-    /**
-     * Tests the mettreAJourObjet method of the ObjetService class.
-     * Verifies that an object is updated correctly.
-     */
     @Test
-    void testMettreAJourObjet() {
+    void obtenirObjetParId_ReturnsNullIfNotExists() {
+        Long id = 1L;
+        when(objetRepository.findById(id)).thenReturn(Optional.empty());
+
+        Objet result = objetService.obtenirObjetParId(id);
+
+        assertNull(result);
+        verify(objetRepository, times(1)).findById(id);
+    }
+
+    @Test
+    void mettreAJourObjet_SavesAndReturnsUpdatedObjet() {
+        Long id = 1L;
         Objet objet = new Objet();
-        when(objetRepository.existsById(1L)).thenReturn(true);
+        when(objetRepository.existsById(id)).thenReturn(true);
         when(objetRepository.save(objet)).thenReturn(objet);
-        assertEquals(objet, objetService.mettreAJourObjet(1L, objet));
+
+        Objet result = objetService.mettreAJourObjet(id, objet);
+
+        assertEquals(objet, result);
+        verify(objetRepository, times(1)).save(objet);
     }
 
-    /**
-     * Tests the supprimerObjet method of the ObjetService class.
-     * Verifies that an object is deleted correctly by its ID.
-     */
     @Test
-    void testSupprimerObjet() {
-        objetService.supprimerObjet(1L);
-        verify(objetRepository, times(1)).deleteById(1L);
+    void mettreAJourObjet_ReturnsNullIfNotExists() {
+        Long id = 1L;
+        Objet objet = new Objet();
+        when(objetRepository.existsById(id)).thenReturn(false);
+
+        Objet result = objetService.mettreAJourObjet(id, objet);
+
+        assertNull(result);
+        verify(objetRepository, times(0)).save(objet);
     }
 
-    /**
-     * Tests the obtenirObjetsParUtilisateur method of the ObjetService class.
-     * Verifies that objects are retrieved correctly by user ID.
-     */
     @Test
-    void testObtenirObjetsParUtilisateur() {
-        objetService.obtenirObjetsParUtilisateur(1L);
-        verify(objetRepository, times(1)).findByUtilisateurId(1L);
+    void supprimerObjet_DeletesObjet() {
+        Long id = 1L;
+
+        objetService.supprimerObjet(id);
+
+        verify(objetRepository, times(1)).deleteById(id);
+    }
+
+    @Test
+    void obtenirObjetsParUtilisateur_ReturnsObjetsIfUserExists() {
+        Long idUtilisateur = 1L;
+        Utilisateur utilisateur = new Utilisateur();
+        utilisateur.setPseudo("user123");
+        utilisateur.setId(idUtilisateur);
+
+        Objet objet1 = new Objet(utilisateur,"Laptop", "A high-end gaming laptop", CategorieObjet.INFORMATIQUE, LocalDateTime.now());
+        Objet objet2 = new Objet(utilisateur,"Smartphone", "A brand new smartphone", CategorieObjet.ELECTROMENAGER, LocalDateTime.now());
+
+        when(utilisateurRepository.findById(idUtilisateur)).thenReturn(Optional.of(utilisateur));
+        when(objetRepository.findByUtilisateurId(idUtilisateur)).thenReturn(Arrays.asList(objet1, objet2));
+
+        List<ObjetDTO> result = objetService.obtenirObjetsParUtilisateur(idUtilisateur);
+
+        assertEquals(2, result.size());
+        assertEquals("Laptop", result.get(0).getNom());
+        assertEquals("Smartphone", result.get(1).getNom());
+        verify(utilisateurRepository, times(1)).findById(idUtilisateur);
+        verify(objetRepository, times(1)).findByUtilisateurId(idUtilisateur);
+    }
+
+    @Test
+    void obtenirObjetsParUtilisateur_ReturnsNullIfUserNotExists() {
+        Long idUtilisateur = 1L;
+        when(utilisateurRepository.findById(idUtilisateur)).thenReturn(Optional.empty());
+
+        List<ObjetDTO> result = objetService.obtenirObjetsParUtilisateur(idUtilisateur);
+
+        assertNull(result);
+        verify(utilisateurRepository, times(1)).findById(idUtilisateur);
+        verify(objetRepository, times(0)).findByUtilisateurId(idUtilisateur);
     }
 }

--- a/Backend/src/test/java/fr/knap/testunitaire_esiee/services/UtilisateurServiceTest.java
+++ b/Backend/src/test/java/fr/knap/testunitaire_esiee/services/UtilisateurServiceTest.java
@@ -20,6 +20,9 @@ import java.util.Optional;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+/**
+ * Unit tests for the UtilisateurService class.
+ */
 @SpringBootTest
 class UtilisateurServiceTest {
 
@@ -32,10 +35,16 @@ class UtilisateurServiceTest {
     @InjectMocks
     private UtilisateurService utilisateurService;
 
+    /**
+     * Initializes mocks for the test class.
+     */
     public UtilisateurServiceTest() {
         MockitoAnnotations.openMocks(this);
     }
 
+    /**
+     * Tests the creerUtilisateur method to ensure it saves and returns the Utilisateur object.
+     */
     @Test
     void creerUtilisateur_SavesAndReturnsUtilisateur() {
         Utilisateur utilisateur = new Utilisateur();
@@ -47,6 +56,9 @@ class UtilisateurServiceTest {
         verify(utilisateurRepository, times(1)).save(utilisateur);
     }
 
+    /**
+     * Tests the obtenirTousLesUtilisateurs method to ensure it returns all Utilisateur objects.
+     */
     @Test
     void obtenirTousLesUtilisateurs_ReturnsAllUtilisateurs() {
         List<Utilisateur> utilisateurs = Arrays.asList(new Utilisateur(), new Utilisateur());
@@ -58,6 +70,9 @@ class UtilisateurServiceTest {
         verify(utilisateurRepository, times(1)).findAll();
     }
 
+    /**
+     * Tests the obtenirUtilisateurParId method to ensure it returns the Utilisateur object if it exists.
+     */
     @Test
     void obtenirUtilisateurParId_ReturnsUtilisateurIfExists() {
         Long id = 1L;
@@ -70,6 +85,9 @@ class UtilisateurServiceTest {
         verify(utilisateurRepository, times(1)).findById(id);
     }
 
+    /**
+     * Tests the obtenirUtilisateurParId method to ensure it returns null if the Utilisateur object does not exist.
+     */
     @Test
     void obtenirUtilisateurParId_ReturnsNullIfNotExists() {
         Long id = 1L;
@@ -81,6 +99,9 @@ class UtilisateurServiceTest {
         verify(utilisateurRepository, times(1)).findById(id);
     }
 
+    /**
+     * Tests the obtenirUtilisateurInfoParId method to ensure it returns the UtilisateurDTO object if the Utilisateur exists.
+     */
     @Test
     void obtenirUtilisateurInfoParId_ReturnsUtilisateurDTOIfExists() {
         Long id = 1L;
@@ -97,6 +118,9 @@ class UtilisateurServiceTest {
         verify(utilisateurRepository, times(1)).findById(id);
     }
 
+    /**
+     * Tests the obtenirUtilisateurInfoParId method to ensure it returns null if the Utilisateur object does not exist.
+     */
     @Test
     void obtenirUtilisateurInfoParId_ReturnsNullIfNotExists() {
         Long id = 1L;
@@ -108,6 +132,9 @@ class UtilisateurServiceTest {
         verify(utilisateurRepository, times(1)).findById(id);
     }
 
+    /**
+     * Tests the obtenirUtilisateurPseudoParId method to ensure it returns the UtilisateurDTO object with only the pseudo field if the Utilisateur exists.
+     */
     @Test
     void obtenirUtilisateurPseudoParId_ReturnsUtilisateurDTOPseudoIfExists() {
         Long id = 1L;
@@ -124,6 +151,9 @@ class UtilisateurServiceTest {
         verify(utilisateurRepository, times(1)).findById(id);
     }
 
+    /**
+     * Tests the obtenirUtilisateurPseudoParId method to ensure it returns null if the Utilisateur object does not exist.
+     */
     @Test
     void obtenirUtilisateurPseudoParId_ReturnsNullIfNotExists() {
         Long id = 1L;
@@ -135,6 +165,9 @@ class UtilisateurServiceTest {
         verify(utilisateurRepository, times(1)).findById(id);
     }
 
+    /**
+     * Tests the mettreAJourUtilisateur method to ensure it saves and returns the updated Utilisateur object.
+     */
     @Test
     void mettreAJourUtilisateur_SavesAndReturnsUpdatedUtilisateur() {
         Long id = 1L;
@@ -148,6 +181,9 @@ class UtilisateurServiceTest {
         verify(utilisateurRepository, times(1)).save(utilisateur);
     }
 
+    /**
+     * Tests the mettreAJourUtilisateur method to ensure it returns null if the Utilisateur object does not exist.
+     */
     @Test
     void mettreAJourUtilisateur_ReturnsNullIfNotExists() {
         Long id = 1L;
@@ -160,6 +196,9 @@ class UtilisateurServiceTest {
         verify(utilisateurRepository, times(0)).save(utilisateur);
     }
 
+    /**
+     * Tests the login method to ensure it returns a Token object if the credentials are valid.
+     */
     @Test
     void login_ReturnsTokenIfCredentialsAreValid() {
         Credentials credentials = new Credentials("user@example.com", "password");
@@ -175,6 +214,9 @@ class UtilisateurServiceTest {
         verify(tokenRepository, times(1)).save(any(Token.class));
     }
 
+    /**
+     * Tests the login method to ensure it returns null if the credentials are invalid.
+     */
     @Test
     void login_ReturnsNullIfCredentialsAreInvalid() {
         Credentials credentials = new Credentials("user@example.com", "wrongpassword");
@@ -187,6 +229,9 @@ class UtilisateurServiceTest {
         verify(tokenRepository, times(0)).save(any(Token.class));
     }
 
+    /**
+     * Tests the verifyToken method to ensure it returns true if the token is valid.
+     */
     @Test
     void verifyToken_ReturnsTrueIfTokenIsValid() {
         String tokenString = "validToken";
@@ -200,6 +245,9 @@ class UtilisateurServiceTest {
         verify(tokenRepository, times(1)).findByToken(tokenString);
     }
 
+    /**
+     * Tests the verifyToken method to ensure it returns false if the token is invalid.
+     */
     @Test
     void verifyToken_ReturnsFalseIfTokenIsInvalid() {
         String tokenString = "invalidToken";
@@ -211,6 +259,9 @@ class UtilisateurServiceTest {
         verify(tokenRepository, times(1)).findByToken(tokenString);
     }
 
+    /**
+     * Tests the disconnect method to ensure it invalidates the token.
+     */
     @Test
     void disconnect_InvalidatesToken() {
         String tokenString = "validToken";
@@ -224,6 +275,9 @@ class UtilisateurServiceTest {
         verify(tokenRepository, times(1)).save(token);
     }
 
+    /**
+     * Tests the supprimerUtilisateur method to ensure it deletes the Utilisateur object.
+     */
     @Test
     void supprimerUtilisateur_DeletesUtilisateur() {
         Long id = 1L;
@@ -233,6 +287,9 @@ class UtilisateurServiceTest {
         verify(utilisateurRepository, times(1)).deleteById(id);
     }
 
+    /**
+     * Tests the obtenirUtilisateurParMail method to ensure it returns the Utilisateur object if it exists.
+     */
     @Test
     void obtenirUtilisateurParMail_ReturnsUtilisateurIfExists() {
         String mail = "user@example.com";
@@ -245,6 +302,9 @@ class UtilisateurServiceTest {
         verify(utilisateurRepository, times(1)).findByMail(mail);
     }
 
+    /**
+     * Tests the obtenirUtilisateurParMail method to ensure it returns null if the Utilisateur object does not exist.
+     */
     @Test
     void obtenirUtilisateurParMail_ReturnsNullIfNotExists() {
         String mail = "user@example.com";
@@ -256,6 +316,9 @@ class UtilisateurServiceTest {
         verify(utilisateurRepository, times(1)).findByMail(mail);
     }
 
+    /**
+     * Tests the obtenirUtilisateurParToken method to ensure it returns the Utilisateur object if the token exists.
+     */
     @Test
     void obtenirUtilisateurParToken_ReturnsUtilisateurIfTokenExists() {
         String mail = "user@example.com";
@@ -275,6 +338,9 @@ class UtilisateurServiceTest {
         verify(utilisateurRepository, times(1)).findByMail(Token.getEmail(token.getToken()));
     }
 
+    /**
+     * Tests the obtenirUtilisateurParToken method to ensure it returns null if the token does not exist.
+     */
     @Test
     void obtenirUtilisateurParToken_ReturnsNullIfTokenNotExists() {
         String tokenString = "invalidToken";
@@ -287,6 +353,9 @@ class UtilisateurServiceTest {
         verify(utilisateurRepository, times(0)).findByMail(anyString());
     }
 
+    /**
+     * Tests the obtenirUtilisateurInfoParToken method to ensure it returns the UtilisateurDTO object if the token exists.
+     */
     @Test
     void obtenirUtilisateurInfoParToken_ReturnsUtilisateurDTOIfTokenExists() {
         Utilisateur utilisateur = new Utilisateur(
@@ -308,6 +377,9 @@ class UtilisateurServiceTest {
         verify(utilisateurRepository, times(1)).findByMail(Token.getEmail(token.getToken()));
     }
 
+    /**
+     * Tests the obtenirUtilisateurInfoParToken method to ensure it returns null if the token does not exist.
+     */
     @Test
     void obtenirUtilisateurInfoParToken_ReturnsNullIfTokenNotExists() {
         String tokenString = "invalidToken";

--- a/Backend/src/test/java/fr/knap/testunitaire_esiee/services/UtilisateurServiceTest.java
+++ b/Backend/src/test/java/fr/knap/testunitaire_esiee/services/UtilisateurServiceTest.java
@@ -1,125 +1,322 @@
 package fr.knap.testunitaire_esiee.services;
 
+import fr.knap.testunitaire_esiee.dto.UtilisateurDTO;
+import fr.knap.testunitaire_esiee.model.Credentials;
+import fr.knap.testunitaire_esiee.model.Token;
 import fr.knap.testunitaire_esiee.model.Utilisateur;
 import fr.knap.testunitaire_esiee.repository.UtilisateurRepository;
-import org.junit.jupiter.api.BeforeEach;
+import fr.knap.testunitaire_esiee.repository.TokenRepository;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.springframework.boot.test.context.SpringBootTest;
 
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
-/**
- * Unit tests for the UtilisateurService class.
- */
+@SpringBootTest
 class UtilisateurServiceTest {
 
     @Mock
     private UtilisateurRepository utilisateurRepository;
 
+    @Mock
+    private TokenRepository tokenRepository;
+
     @InjectMocks
     private UtilisateurService utilisateurService;
 
-    /**
-     * Sets up the test environment before each test.
-     * Initializes the mocks and injects them into the UtilisateurService instance.
-     */
-    @BeforeEach
-    void setUp() {
+    public UtilisateurServiceTest() {
         MockitoAnnotations.openMocks(this);
     }
 
-    /**
-     * Tests the creerUtilisateur method of the UtilisateurService class.
-     * Verifies that a user is created and saved correctly.
-     */
     @Test
-    void testCreerUtilisateur() {
+    void creerUtilisateur_SavesAndReturnsUtilisateur() {
         Utilisateur utilisateur = new Utilisateur();
         when(utilisateurRepository.save(utilisateur)).thenReturn(utilisateur);
-        assertEquals(utilisateur, utilisateurService.creerUtilisateur(utilisateur));
+
+        Utilisateur result = utilisateurService.creerUtilisateur(utilisateur);
+
+        assertEquals(utilisateur, result);
+        verify(utilisateurRepository, times(1)).save(utilisateur);
     }
 
-    /**
-     * Tests the obtenirTousLesUtilisateurs method of the UtilisateurService class.
-     * Verifies that all users are retrieved correctly.
-     */
     @Test
-    void testObtenirTousLesUtilisateurs() {
-        utilisateurService.obtenirTousLesUtilisateurs();
+    void obtenirTousLesUtilisateurs_ReturnsAllUtilisateurs() {
+        List<Utilisateur> utilisateurs = Arrays.asList(new Utilisateur(), new Utilisateur());
+        when(utilisateurRepository.findAll()).thenReturn(utilisateurs);
+
+        List<Utilisateur> result = utilisateurService.obtenirTousLesUtilisateurs();
+
+        assertEquals(utilisateurs, result);
         verify(utilisateurRepository, times(1)).findAll();
     }
 
-    /**
-     * Tests the obtenirUtilisateurParId method of the UtilisateurService class.
-     * Verifies that a user is retrieved correctly by its ID.
-     */
     @Test
-    void testObtenirUtilisateurParId() {
+    void obtenirUtilisateurParId_ReturnsUtilisateurIfExists() {
+        Long id = 1L;
         Utilisateur utilisateur = new Utilisateur();
-        when(utilisateurRepository.findById(1L)).thenReturn(Optional.of(utilisateur));
-        assertEquals(utilisateur, utilisateurService.obtenirUtilisateurParId(1L));
+        when(utilisateurRepository.findById(id)).thenReturn(Optional.of(utilisateur));
+
+        Utilisateur result = utilisateurService.obtenirUtilisateurParId(id);
+
+        assertEquals(utilisateur, result);
+        verify(utilisateurRepository, times(1)).findById(id);
     }
 
-    /**
-     * Tests the mettreAJourUtilisateur method of the UtilisateurService class.
-     * Verifies that a user is updated correctly.
-     */
     @Test
-    void testMettreAJourUtilisateur() {
+    void obtenirUtilisateurParId_ReturnsNullIfNotExists() {
+        Long id = 1L;
+        when(utilisateurRepository.findById(id)).thenReturn(Optional.empty());
+
+        Utilisateur result = utilisateurService.obtenirUtilisateurParId(id);
+
+        assertNull(result);
+        verify(utilisateurRepository, times(1)).findById(id);
+    }
+
+    @Test
+    void obtenirUtilisateurInfoParId_ReturnsUtilisateurDTOIfExists() {
+        Long id = 1L;
+        Utilisateur utilisateur = new Utilisateur(
+                "user123", "mdp", "Doe.John@mail.com", "Doe", "John"
+        );
+        when(utilisateurRepository.findById(id)).thenReturn(Optional.of(utilisateur));
+
+        UtilisateurDTO result = utilisateurService.obtenirUtilisateurInfoParId(id);
+
+        assertEquals("user123", result.getPseudo());
+        assertEquals("Doe", result.getNom());
+        assertEquals("John", result.getPrenom());
+        verify(utilisateurRepository, times(1)).findById(id);
+    }
+
+    @Test
+    void obtenirUtilisateurInfoParId_ReturnsNullIfNotExists() {
+        Long id = 1L;
+        when(utilisateurRepository.findById(id)).thenReturn(Optional.empty());
+
+        UtilisateurDTO result = utilisateurService.obtenirUtilisateurInfoParId(id);
+
+        assertNull(result);
+        verify(utilisateurRepository, times(1)).findById(id);
+    }
+
+    @Test
+    void obtenirUtilisateurPseudoParId_ReturnsUtilisateurDTOPseudoIfExists() {
+        Long id = 1L;
+        Utilisateur utilisateur = new Utilisateur(
+                "user123", "mdp", "Doe.John@mail.com", "Doe", "John"
+        );
+        when(utilisateurRepository.findById(id)).thenReturn(Optional.of(utilisateur));
+
+        UtilisateurDTO result = utilisateurService.obtenirUtilisateurPseudoParId(id);
+
+        assertEquals("user123", result.getPseudo());
+        assertNull(result.getNom());
+        assertNull(result.getPrenom());
+        verify(utilisateurRepository, times(1)).findById(id);
+    }
+
+    @Test
+    void obtenirUtilisateurPseudoParId_ReturnsNullIfNotExists() {
+        Long id = 1L;
+        when(utilisateurRepository.findById(id)).thenReturn(Optional.empty());
+
+        UtilisateurDTO result = utilisateurService.obtenirUtilisateurPseudoParId(id);
+
+        assertNull(result);
+        verify(utilisateurRepository, times(1)).findById(id);
+    }
+
+    @Test
+    void mettreAJourUtilisateur_SavesAndReturnsUpdatedUtilisateur() {
+        Long id = 1L;
         Utilisateur utilisateur = new Utilisateur();
-        when(utilisateurRepository.existsById(1L)).thenReturn(true);
+        when(utilisateurRepository.existsById(id)).thenReturn(true);
         when(utilisateurRepository.save(utilisateur)).thenReturn(utilisateur);
-        assertEquals(utilisateur, utilisateurService.mettreAJourUtilisateur(1L, utilisateur));
+
+        Utilisateur result = utilisateurService.mettreAJourUtilisateur(id, utilisateur);
+
+        assertEquals(utilisateur, result);
+        verify(utilisateurRepository, times(1)).save(utilisateur);
     }
 
-    // TODO: Fix the test
-    // /**
-    //  * Tests the login method of the UtilisateurService class.
-    //  * Verifies that a user is logged in correctly.
-    //  */
-    // @Test
-    // void testLogin() {
-    //     Credentials credentials = new Credentials("test@mail.com", "password");
-    //     when(utilisateurRepository.existsByMail(credentials.getMail())).thenReturn(true);
-    //     when(utilisateurRepository.existsByMdp(credentials.getMdp())).thenReturn(true);
-    //     assertNotNull(utilisateurService.login(credentials));
-    // }
-
-    // TODO: Fix the test
-    // /**
-    //  * Tests the login method of the UtilisateurService class.
-    //  * Verifies that a user is not logged in with incorrect credentials.
-    //  */
-    // @Test
-    // void testDisconnect() {
-    //     Token token = new Token("test@mail.com", "password");
-    //     token.disconnect();
-    //     assertNull(token.getToken());
-    // }
-
-    // TODO: Fix the test
-    // /**
-    //  * Tests the verifyToken method of the UtilisateurService class.
-    //  * Verifies that a token is verified correctly.
-    //  */
-    // @Test
-    // void testVerifyToken() {
-    //     Token token = new Token("test@mail.com", "password");
-    //     assertTrue(utilisateurService.verifyToken(token.getToken()));
-    // }
-
-    /**
-     * Tests the supprimerUtilisateur method of the UtilisateurService class.
-     * Verifies that a user is deleted correctly by its ID.
-     */
     @Test
-    void testSupprimerUtilisateur() {
-        utilisateurService.supprimerUtilisateur(1L);
-        verify(utilisateurRepository, times(1)).deleteById(1L);
+    void mettreAJourUtilisateur_ReturnsNullIfNotExists() {
+        Long id = 1L;
+        Utilisateur utilisateur = new Utilisateur();
+        when(utilisateurRepository.existsById(id)).thenReturn(false);
+
+        Utilisateur result = utilisateurService.mettreAJourUtilisateur(id, utilisateur);
+
+        assertNull(result);
+        verify(utilisateurRepository, times(0)).save(utilisateur);
+    }
+
+    @Test
+    void login_ReturnsTokenIfCredentialsAreValid() {
+        Credentials credentials = new Credentials("user@example.com", "password");
+        Utilisateur utilisateur = new Utilisateur();
+        when(utilisateurRepository.findByMailAndMdp(credentials.getMail(), credentials.getMdp())).thenReturn(Optional.of(utilisateur));
+        Token token = new Token(credentials.getMail(), credentials.getMdp());
+        when(tokenRepository.save(any(Token.class))).thenReturn(token);
+
+        Token result = utilisateurService.login(credentials);
+
+        assertEquals(token, result);
+        verify(utilisateurRepository, times(1)).findByMailAndMdp(credentials.getMail(), credentials.getMdp());
+        verify(tokenRepository, times(1)).save(any(Token.class));
+    }
+
+    @Test
+    void login_ReturnsNullIfCredentialsAreInvalid() {
+        Credentials credentials = new Credentials("user@example.com", "wrongpassword");
+        when(utilisateurRepository.findByMailAndMdp(credentials.getMail(), credentials.getMdp())).thenReturn(Optional.empty());
+
+        Token result = utilisateurService.login(credentials);
+
+        assertNull(result);
+        verify(utilisateurRepository, times(1)).findByMailAndMdp(credentials.getMail(), credentials.getMdp());
+        verify(tokenRepository, times(0)).save(any(Token.class));
+    }
+
+    @Test
+    void verifyToken_ReturnsTrueIfTokenIsValid() {
+        String tokenString = "validToken";
+        Token token = new Token();
+        token.setExpirationDate(new Date(System.currentTimeMillis() + 10000));
+        when(tokenRepository.findByToken(tokenString)).thenReturn(Optional.of(token));
+
+        boolean result = utilisateurService.verifyToken(tokenString);
+
+        assertTrue(result);
+        verify(tokenRepository, times(1)).findByToken(tokenString);
+    }
+
+    @Test
+    void verifyToken_ReturnsFalseIfTokenIsInvalid() {
+        String tokenString = "invalidToken";
+        when(tokenRepository.findByToken(tokenString)).thenReturn(Optional.empty());
+
+        boolean result = utilisateurService.verifyToken(tokenString);
+
+        assertFalse(result);
+        verify(tokenRepository, times(1)).findByToken(tokenString);
+    }
+
+    @Test
+    void disconnect_InvalidatesToken() {
+        String tokenString = "validToken";
+        Token token = new Token();
+        when(tokenRepository.findByToken(tokenString)).thenReturn(Optional.of(token));
+
+        utilisateurService.disconnect(tokenString);
+
+        assertTrue(!Token.validateToken(token.getToken()));
+        verify(tokenRepository, times(1)).findByToken(tokenString);
+        verify(tokenRepository, times(1)).save(token);
+    }
+
+    @Test
+    void supprimerUtilisateur_DeletesUtilisateur() {
+        Long id = 1L;
+
+        utilisateurService.supprimerUtilisateur(id);
+
+        verify(utilisateurRepository, times(1)).deleteById(id);
+    }
+
+    @Test
+    void obtenirUtilisateurParMail_ReturnsUtilisateurIfExists() {
+        String mail = "user@example.com";
+        Utilisateur utilisateur = new Utilisateur();
+        when(utilisateurRepository.findByMail(mail)).thenReturn(Optional.of(utilisateur));
+
+        Utilisateur result = utilisateurService.obtenirUtilisateurParMail(mail);
+
+        assertEquals(utilisateur, result);
+        verify(utilisateurRepository, times(1)).findByMail(mail);
+    }
+
+    @Test
+    void obtenirUtilisateurParMail_ReturnsNullIfNotExists() {
+        String mail = "user@example.com";
+        when(utilisateurRepository.findByMail(mail)).thenReturn(Optional.empty());
+
+        Utilisateur result = utilisateurService.obtenirUtilisateurParMail(mail);
+
+        assertNull(result);
+        verify(utilisateurRepository, times(1)).findByMail(mail);
+    }
+
+    @Test
+    void obtenirUtilisateurParToken_ReturnsUtilisateurIfTokenExists() {
+        String mail = "user@example.com";
+        String mdp = "password";
+        Token token = new Token(mail, mdp);
+        String tokenString = token.getToken();
+        Utilisateur utilisateur = new Utilisateur();
+        when(tokenRepository.findByToken(tokenString)).thenReturn(Optional.of(token));
+        when(
+                utilisateurRepository.findByMail(Token.getEmail(token.getToken()))
+        ).thenReturn(Optional.of(utilisateur));
+
+        Utilisateur result = utilisateurService.obtenirUtilisateurParToken(tokenString);
+
+        assertEquals(utilisateur, result);
+        verify(tokenRepository, times(1)).findByToken(tokenString);
+        verify(utilisateurRepository, times(1)).findByMail(Token.getEmail(token.getToken()));
+    }
+
+    @Test
+    void obtenirUtilisateurParToken_ReturnsNullIfTokenNotExists() {
+        String tokenString = "invalidToken";
+        when(tokenRepository.findByToken(tokenString)).thenReturn(Optional.empty());
+
+        Utilisateur result = utilisateurService.obtenirUtilisateurParToken(tokenString);
+
+        assertNull(result);
+        verify(tokenRepository, times(1)).findByToken(tokenString);
+        verify(utilisateurRepository, times(0)).findByMail(anyString());
+    }
+
+    @Test
+    void obtenirUtilisateurInfoParToken_ReturnsUtilisateurDTOIfTokenExists() {
+        Utilisateur utilisateur = new Utilisateur(
+                "user123", "mdp", "Doe.John@mail.com", "Doe", "John"
+        );
+        Token token = new Token(utilisateur.getMail(), utilisateur.getMdp());
+        String tokenString = token.getToken();
+        when(tokenRepository.findByToken(tokenString)).thenReturn(Optional.of(token));
+        when(
+                utilisateurRepository.findByMail(Token.getEmail(token.getToken()))
+        ).thenReturn(Optional.of(utilisateur));
+
+        UtilisateurDTO result = utilisateurService.obtenirUtilisateurInfoParToken(tokenString);
+
+        assertEquals("user123", result.getPseudo());
+        assertEquals("Doe", result.getNom());
+        assertEquals("John", result.getPrenom());
+        verify(tokenRepository, times(1)).findByToken(tokenString);
+        verify(utilisateurRepository, times(1)).findByMail(Token.getEmail(token.getToken()));
+    }
+
+    @Test
+    void obtenirUtilisateurInfoParToken_ReturnsNullIfTokenNotExists() {
+        String tokenString = "invalidToken";
+        when(tokenRepository.findByToken(tokenString)).thenReturn(Optional.empty());
+
+        UtilisateurDTO result = utilisateurService.obtenirUtilisateurInfoParToken(tokenString);
+
+        assertNull(result);
+        verify(tokenRepository, times(1)).findByToken(tokenString);
+        verify(utilisateurRepository, times(0)).findByMail(anyString());
     }
 }


### PR DESCRIPTION
This pull request includes several changes to improve the codebase by refactoring the `Config` class and updating the `CredentialsController` and `EchangeController` classes. The most important changes are the refactoring of user creation and object assignment in the `Config` class, and the introduction of `TokenCredentialDTO` in the `CredentialsController`.

Refactoring and improvements:

* [`Backend/src/main/java/fr/knap/testunitaire_esiee/config/Config.java`](diffhunk://#diff-7068c87bd515304158fcd4bcda485bf0b0fe16729f190e32a329ac0fb34e318cR14-R15): Refactored the creation of `Utilisateur` objects using a `List` and streamlined the saving process. Updated object assignments to use random user IDs. [[1]](diffhunk://#diff-7068c87bd515304158fcd4bcda485bf0b0fe16729f190e32a329ac0fb34e318cR14-R15) [[2]](diffhunk://#diff-7068c87bd515304158fcd4bcda485bf0b0fe16729f190e32a329ac0fb34e318cL36-R280)

Controller updates:

* [`Backend/src/main/java/fr/knap/testunitaire_esiee/controller/CredentialsController.java`](diffhunk://#diff-c007c9d7d107e8f46ca156cec6bae11d89ffd6e64f629a207d4b806047bf5bd5L5-R5): Replaced `TokenCredential` with `TokenCredentialDTO` in the `creerUtilisateur`, `getConnexionToken`, `disconnect`, and `verifyToken` methods. [[1]](diffhunk://#diff-c007c9d7d107e8f46ca156cec6bae11d89ffd6e64f629a207d4b806047bf5bd5L5-R5) [[2]](diffhunk://#diff-c007c9d7d107e8f46ca156cec6bae11d89ffd6e64f629a207d4b806047bf5bd5L30-R32) [[3]](diffhunk://#diff-c007c9d7d107e8f46ca156cec6bae11d89ffd6e64f629a207d4b806047bf5bd5L49-R52) [[4]](diffhunk://#diff-c007c9d7d107e8f46ca156cec6bae11d89ffd6e64f629a207d4b806047bf5bd5L65-R65) [[5]](diffhunk://#diff-c007c9d7d107e8f46ca156cec6bae11d89ffd6e64f629a207d4b806047bf5bd5L80-R80)
* [`Backend/src/main/java/fr/knap/testunitaire_esiee/controller/EchangeController.java`](diffhunk://#diff-88d573534a7e4073a3bcb37dade411b461a305283976d29476f733c28ce7b515R5): Added `UtilisateurService` and updated the `obtenirUnEchange` method to verify the authorization token before returning the exchange. [[1]](diffhunk://#diff-88d573534a7e4073a3bcb37dade411b461a305283976d29476f733c28ce7b515R5) [[2]](diffhunk://#diff-88d573534a7e4073a3bcb37dade411b461a305283976d29476f733c28ce7b515R22-R23) [[3]](diffhunk://#diff-88d573534a7e4073a3bcb37dade411b461a305283976d29476f733c28ce7b515L50-R56)