### PR TITLE
Merge `dev` to `master`

### DIFF
--- a/.github/workflows/generate-javadoc-release.yml
+++ b/.github/workflows/generate-javadoc-release.yml
@@ -46,7 +46,6 @@ jobs:
       - name: Upload JavaDoc to GitHub Release
         uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda  # v2.2.1
         with:
-          name: javadoc
           files: javadoc.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request includes a minor update to the `.github/workflows/generate-javadoc-release.yml` file. The change involves removing the `name` parameter from the `Upload JavaDoc to GitHub Release` step.

* [`.github/workflows/generate-javadoc-release.yml`](diffhunk://#diff-c928d53813688d7afe89d949bf767324c2426d778e80550c1a706e9edd4b7430L49): Removed the `name` parameter from the `Upload JavaDoc to GitHub Release` step.